### PR TITLE
Adding cantaloupe🍈 to playbook

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -18,6 +18,8 @@ tomcat8_java_opts:
   - -XX:MaxPermSize=256m
   - -Dfcrepo.modeshape.configuration=file://{{ fcrepo_home_dir }}/configs/repository.json
   - -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile={{ blazegraph_home_dir }}/conf/RWStore.properties
+  - -Dcantaloupe.config={{ cantaloupe_symlink }}/cantaloupe.properties
+  - -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
 
 fcrepo_syn_sites:
   - algorithm: RS256
@@ -31,3 +33,21 @@ fcrepo_syn_tokens:
     roles:
       - admin
     token: islandora
+
+cantaloupe_deploy_war: yes
+cantaloupe_deploy_war_path: "{{ tomcat8_home }}/webapps"
+cantaloupe_user: tomcat8
+cantaloupe_group: tomcat8
+cantaloupe_admin_enabled: "true"
+cantaloupe_admin_password: islandora
+cantaloupe_OpenJpegProcessor_path_to_binaries: /usr/bin
+cantaloupe_log_application_ConsoleAppender_enabled: "false"
+cantaloupe_log_application_FileAppender_enabled: "true"
+cantaloupe_log_application_FileAppender_pathname: "{{ cantaloupe_log_path }}/application.log"
+cantaloupe_log_access_FileAppender_enabled: "true"
+cantaloupe_log_access_FileAppender_pathname: "{{ cantaloupe_log_path }}/access.log"
+cantaloupe_FilesystemResolver_BasicLookupStrategy_path_prefix: /var/www/html/drupal/web/
+cantaloupe_processor_jp2: OpenJpegProcessor
+cantaloupe_cache_source: FilesystemCache
+cantaloupe_cache_derivative: FilesystemCache
+cantaloupe_create_FilesystemCache_dir: yes

--- a/roles/internal/cantaloupe/defaults/main.yml
+++ b/roles/internal/cantaloupe/defaults/main.yml
@@ -1,0 +1,610 @@
+---
+
+cantaloupe_version: 3.3.1
+cantaloupe_install_root: /opt
+cantaloupe_symlink: /opt/cantaloupe
+cantaloupe_log_path: /var/log/cantaloupe
+cantaloupe_user: cantaloupe
+cantaloupe_group: cantaloupe
+
+cantaloupe_deploy_war: no
+cantaloupe_deploy_war_path: /path/to/tomcat/webapps
+cantaloupe_deploy_war_filename: cantaloupe
+
+cantaloupe_create_FilesystemCache_dir: no
+
+###########################################################################
+# Cantaloupe.properties config
+###########################################################################
+
+# !! Whether to enable HTTP access (http://), and on what host interface
+# and TCP port. (Applies in standalone mode only.)
+cantaloupe_http_enabled: "true"
+cantaloupe_http_host: 0.0.0.0
+cantaloupe_http_port: 8182
+
+# !! Whether to enable HTTPS access (https://), and on what host interface
+# and TCP port. (Applies in standalone mode only.)
+cantaloupe_https_enabled: "false"
+cantaloupe_https_host: 0.0.0.0
+cantaloupe_https_port: 8183
+
+# !! Available values are `JKS` and `PKCS12`. (Standalone mode only.)
+cantaloupe_https_key_store_type: JKS
+cantaloupe_https_key_store_password: myPassword
+cantaloupe_https_key_store_path: /path/to/keystore.jks
+cantaloupe_https_key_password: myPassword
+
+# !! Configures HTTP Basic authentication.
+cantaloupe_auth_basic_enabled: "false"
+cantaloupe_auth_basic_username: myself
+cantaloupe_auth_basic_secret: mypassword
+
+# Enables the Control Panel, at /admin.
+cantaloupe_admin_enabled: "false"
+# Password to access the Control Panel. (The username is "admin".)
+cantaloupe_admin_password:
+
+# Base URI to use for internal links, such as Link headers and JSON-LD @id
+# values, in a reverse-proxy context. This should only be used when
+# X-Forwarded-* headers cannot be used instead (see the user manual).
+cantaloupe_base_uri:
+
+# Normally, slashes in a URI path component must be percent-encoded as
+# "%2F". If your proxy is incapable of passing these through without
+# decoding them, you can define an alternate character or character
+# sequence to substitute for a slash. Supply the non-percent-encoded
+# version here, and use the percent-encoded version in URLs.
+cantaloupe_slash_substitute:
+
+# Maximum number of pixels to return in a response, to prevent overloading
+# the server. Requests for more pixels than this will receive an error
+# response. Set to 0 for no maximum.
+cantaloupe_max_pixels: 400000000
+
+# Sometimes helpful.
+cantaloupe_print_stack_trace_on_error_pages: "true"
+
+###########################################################################
+# DELEGATE SCRIPT
+###########################################################################
+
+# !! Enables the delegate script: a Ruby script containing various delegate
+# methods. (See the user manual.)
+cantaloupe_delegate_script_enabled: "false"
+
+# !! This can be an absolute path, or a filename; if only a
+# filename is specified, it will be searched for in the same folder as this
+# file, and then the current working directory.
+cantaloupe_delegate_script_pathname: delegates.rb
+
+# Enables the invocation cache, which caches method invocations and
+# return values in memory. See the user manual for more information.
+cantaloupe_delegate_script_cache_enabled: "false"
+
+###########################################################################
+# ENDPOINTS
+###########################################################################
+
+cantaloupe_endpoint_iiif_1_enabled: "true"
+
+cantaloupe_endpoint_iiif_2_enabled: "true"
+
+# Controls the response Content-Disposition header for images. Allowed
+# values are `inline`, `attachment`, and `none`.
+cantaloupe_endpoint_iiif_content_disposition: inline
+
+# Minimum size that will be used in info.json "tiles" keys. See the user
+# manual for an explanation of how these are calculated.
+cantaloupe_endpoint_iiif_min_tile_size: 1024
+
+# If "true", requests for sizes other than those specified in an info.json
+# response will be denied.
+cantaloupe_endpoint_iiif_2_restrict_to_sizes: "false"
+
+# Enables the administrative REST API. (See the user manual.)
+cantaloupe_endpoint_api_enabled: "false"
+
+# HTTP Basic credentials to access the REST API.
+cantaloupe_endpoint_api_username:
+cantaloupe_endpoint_api_secret:
+
+###########################################################################
+# RESOLVERS
+###########################################################################
+
+# Specifies one resolver to translate the identifier in the URL to an image
+# source for all requests. Available values are `FilesystemResolver`,
+# `HttpResolver`, `JdbcResolver`, `AmazonS3Resolver`, and
+# `AzureStorageResolver`.
+cantaloupe_resolver_static: FilesystemResolver
+
+# If "true", `resolver_static` will be overridden, and the
+# `get_resolver(identifier)` delegate script method will be used to select
+# a resolver per-request.
+cantaloupe_resolver_delegate: "false"
+
+#----------------------------------------
+# FilesystemResolver
+#----------------------------------------
+
+# Tells FilesystemResolver how to look up files. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses the delegate script for dynamic lookups; see the user manual for
+# details.
+cantaloupe_FilesystemResolver_lookup_strategy: BasicLookupStrategy
+
+# Server-side path that will be prefixed to the identifier in the URL.
+# Trailing slash is important.
+cantaloupe_FilesystemResolver_BasicLookupStrategy_path_prefix: /home/myself/images/
+
+
+# Server-side path or extension that will be suffixed to the identifier in
+# the URL.
+cantaloupe_FilesystemResolver_BasicLookupStrategy_path_suffix:
+
+#----------------------------------------
+# HttpResolver
+#----------------------------------------
+
+# Tells HttpResolver how to look up resources. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses the delegate script for dynamic lookups; see the user manual for
+# details.
+cantaloupe_HttpResolver_lookup_strategy: BasicLookupStrategy
+
+# URL that will be prefixed to the identifier in the request URL. Trailing
+# slash is important.
+cantaloupe_HttpResolver_BasicLookupStrategy_url_prefix: http://localhost/images/
+
+# Path, extension, query string, etc. that will be suffixed to the
+# identifier in the request URL.
+cantaloupe_HttpResolver_BasicLookupStrategy_url_suffix:
+
+# Used for HTTP Basic authentication.
+cantaloupe_HttpResolver_auth_basic_username:
+cantaloupe_HttpResolver_auth_basic_secret:
+
+#----------------------------------------
+# JdbcResolver
+#----------------------------------------
+
+# Note: JdbcResolver requires some delegate methods to be implemented in
+# addition to the configuration here; see the user manual.
+
+# !!
+cantaloupe_JdbcResolver_url: jdbc:postgresql://localhost:5432/my_database
+# !!
+cantaloupe_JdbcResolver_user: postgres
+# !!
+cantaloupe_JdbcResolver_password: postgres
+
+# !! Connection timeout in seconds.
+cantaloupe_JdbcResolver_connection_timeout: 10
+
+#----------------------------------------
+# AmazonS3Resolver
+#----------------------------------------
+
+# !! Access key ID and secret key associated with your AWS account.
+# See: http://aws.amazon.com/security-credentials
+cantaloupe_AmazonS3Resolver_access_key_id:
+cantaloupe_AmazonS3Resolver_secret_key:
+
+# !! Name of the bucket containing images to be served.
+cantaloupe_AmazonS3Resolver_bucket_name:
+
+# !! Can be left blank.
+# See: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+cantaloupe_AmazonS3Resolver_bucket_region:
+
+# Tells AmazonS3Resolver how to look up objects. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses the delegate script for dynamic lookups; see the user manual for
+# details.
+cantaloupe_AmazonS3Resolver_lookup_strategy: BasicLookupStrategy
+
+#----------------------------------------
+# AzureStorageResolver
+#----------------------------------------
+
+# !! Name of your Azure account.
+cantaloupe_AzureStorageResolver_account_name:
+
+# !! Key of your Azure account.
+cantaloupe_AzureStorageResolver_account_key:
+
+# !! Name of the container containing images to be served.
+cantaloupe_AzureStorageResolver_container_name:
+
+# Tells AzureStorageResolver how to look up objects. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses the delegate script for dynamic lookups; see the user manual for
+# details.
+cantaloupe_AzureStorageResolver_lookup_strategy: BasicLookupStrategy
+
+###########################################################################
+# PROCESSORS
+###########################################################################
+
+#----------------------------------------
+# Processor Selection
+#----------------------------------------
+
+# Image processors to use for various source formats. Available values are
+# `Java2dProcessor`, `GraphicsMagickProcessor`, `ImageMagickProcessor`,
+# `KakaduProcessor`, `OpenJpegProcessor`, `JaiProcessor`, `PdfBoxProcessor`,
+# and `FfmpegProcessor`.
+
+# These extension-specific definitions are optional.
+cantaloupe_processor_avi: FfmpegProcessor
+cantaloupe_processor_bmp:
+cantaloupe_processor_dcm:
+cantaloupe_processor_gif:
+cantaloupe_processor_jp2: KakaduProcessor
+cantaloupe_processor_jpg:
+cantaloupe_processor_mov: FfmpegProcessor
+cantaloupe_processor_mp4: FfmpegProcessor
+cantaloupe_processor_mpg: FfmpegProcessor
+cantaloupe_processor_pdf: PdfBoxProcessor
+cantaloupe_processor_png:
+cantaloupe_processor_tif:
+cantaloupe_processor_webm: FfmpegProcessor
+cantaloupe_processor_webp: ImageMagickProcessor
+
+# Fall back to this processor for any formats not assigned above.
+cantaloupe_processor_fallback: Java2dProcessor
+
+#----------------------------------------
+# Global Processor Configuration
+#----------------------------------------
+
+# Expands contrast to utilize available dynamic range. This forces the entire
+# source image to be read into memory, so can be slow with large images.
+cantaloupe_processor_normalize: "false"
+
+# Color of the background when an image is rotated. Only affects output
+# formats that do not support transparency.
+cantaloupe_processor_background_color: black
+
+# Available values are `bell`, `bspline`, `bicubic`, `box`, `hermite`,
+# `lanczos3`, `mitchell`, `triangle`.
+# These are used only by FfmpegProcessor, Java2dProcessor, OpenJpegProcessor,
+# and PdfBoxProcessor.
+cantaloupe_processor_downscale_filter: bicubic
+cantaloupe_processor_upscale_filter: bicubic
+
+# Intensity of an unsharp mask from 0 to 1.
+cantaloupe_processor_sharpen: 0
+
+# Progressive JPEGs are generally more space-efficient.
+cantaloupe_processor_jpg_progressive: "true"
+
+# JPEG output quality (1-100).
+cantaloupe_processor_jpg_quality: 80
+
+# TIFF output compression type. Available values are `Deflate`, `JPEG`,
+# `LZW`, and `RLE`. Leave blank for no compression.
+cantaloupe_processor_tif_compression: LZW
+
+# Available values are `StreamStrategy` and `CacheStrategy`. StreamStrategy
+# will try to stream source images from non-filesystem resolvers, when this
+# is possible; CacheStrategy will first download them into the source cache
+# using FilesystemCache, which must also be configured.
+cantaloupe_StreamProcessor_retrieval_strategy: StreamStrategy
+
+#----------------------------------------
+# FfmpegProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing the FFmpeg binaries.
+# Overrides the PATH.
+cantaloupe_FfmpegProcessor_path_to_binaries:
+
+#----------------------------------------
+# GraphicsMagickProcessor
+#----------------------------------------
+
+# !! Optional absolute path of the directory containing the GraphicsMagick
+# binary. Overrides the PATH.
+cantaloupe_GraphicsMagickProcessor_path_to_binaries:
+
+#----------------------------------------
+# ImageMagickProcessor
+#----------------------------------------
+
+# !! Optional absolute path of the directory containing the ImageMagick
+# binaries. Overrides the PATH.
+cantaloupe_ImageMagickProcessor_path_to_binaries:
+
+#----------------------------------------
+# KakaduProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing the Kakadu binaries.
+# Overrides the PATH.
+cantaloupe_KakaduProcessor_path_to_binaries:
+
+#----------------------------------------
+# OpenJpegProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing the OpenJPEG binaries.
+# Overrides the PATH.
+cantaloupe_OpenJpegProcessor_path_to_binaries:
+
+#----------------------------------------
+# PdfBoxProcessor
+#----------------------------------------
+
+# Resolution of the PDF rasterization at a scale of 1. Requests for
+# scales less than 0.5 or larger than 2 will automatically use a lower or
+# higher factor of this.
+cantaloupe_PdfBoxProcessor_dpi: 150
+
+###########################################################################
+# CLIENT-SIDE CACHING
+###########################################################################
+
+# Whether to enable the response Cache-Control header.
+cantaloupe_cache_client_enabled: "true"
+
+cantaloupe_cache_client_max_age: 2592000
+cantaloupe_cache_client_shared_max_age:
+cantaloupe_cache_client_public: "true"
+cantaloupe_cache_client_private: "false"
+cantaloupe_cache_client_no_cache: "false"
+cantaloupe_cache_client_no_store: "false"
+cantaloupe_cache_client_must_revalidate: "false"
+cantaloupe_cache_client_proxy_revalidate: "false"
+cantaloupe_cache_client_no_transform: "true"
+
+###########################################################################
+# SERVER-SIDE CACHING
+###########################################################################
+
+# Enables the source cache. The only available value is `FilesystemCache`.
+# Set blank to disable source image caching.
+# Note that source images will only be cached when a FileProcessor is used
+# with a StreamResolver, or when a StreamProcessor is used with
+# `StreamProcessor.retrieval_strategy` set to `CacheStrategy`.
+cantaloupe_cache_source:
+
+# Enables the derivative (processed image) cache. Available values are
+# `FilesystemCache`, `JdbcCache`, `AmazonS3Cache`, and `AzureStorageCache`.
+# Set blank to disable derivative caching.
+cantaloupe_cache_derivative:
+
+# Time before a cached image becomes stale and needs to be reloaded. Set to
+# blank or 0 for infinite.
+cantaloupe_cache_server_ttl_seconds: 2592000
+
+# If "true", when a resolver reports that the requested source image has gone
+# missing, all cached information relating to it (if any) will be deleted.
+# (This is effectively always "false" when cache.server.resolve_first is also
+# "false".)
+cantaloupe_cache_server_purge_missing: "false"
+
+# If "true", the source image will be confirmed to exist before a cached copy
+# is returned. If "false", the cached copy will be returned without any
+# checking. Resolving first is slower but safer.
+cantaloupe_cache_server_resolve_first: "false"
+
+# !! Enables the cache worker, which periodically purges expired cache
+# items in the background.
+cantaloupe_cache_server_worker_enabled: "false"
+
+# !! The cache worker will wait this many seconds between purgings.
+cantaloupe_cache_server_worker_interval: 86400
+
+#----------------------------------------
+# FilesystemCache
+#----------------------------------------
+
+# If this directory does not exist, it will be created automatically.
+cantaloupe_FilesystemCache_pathname: /var/cache/cantaloupe
+
+# Levels of folder hierarchy in which to store cached images. Deeper depth
+# results in fewer files per directory. Set to 0 to disable subfolders.
+# Purge the cache after changing this.
+cantaloupe_FilesystemCache_dir_depth: 3
+
+# Number of characters in hierarchy directory names. Should be set to
+# 16^n < (max number of directory entries your filesystem can deal with).
+# Purge the cache after changing this.
+cantaloupe_FilesystemCache_dir_name_length: 2
+
+#----------------------------------------
+# JdbcCache
+#----------------------------------------
+
+# !!
+cantaloupe_JdbcCache_url: jdbc:postgresql://localhost:5432/cantaloupe
+# !!
+cantaloupe_JdbcCache_user: postgres
+# !!
+cantaloupe_JdbcCache_password:
+
+# !! Connection timeout in seconds.
+cantaloupe_JdbcCache_connection_timeout: 10
+
+# These must be created manually; see the user manual.
+cantaloupe_JdbcCache_derivative_image_table: derivative_cache
+cantaloupe_JdbcCache_info_table: info_cache
+
+#----------------------------------------
+# AmazonS3Cache
+#----------------------------------------
+
+# !! Access key ID and secret key associated with your AWS account.
+# See: http://aws.amazon.com/security-credentials
+cantaloupe_AmazonS3Cache_access_key_id:
+cantaloupe_AmazonS3Cache_secret_key:
+
+# !! Name of a bucket to use to hold cached data.
+cantaloupe_AmazonS3Cache_bucket_name:
+
+# !! Can be left blank.
+# See: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+cantaloupe_AmazonS3Cache_bucket_region:
+
+# !! String that will be prefixed to object keys.
+cantaloupe_AmazonS3Cache_object_key_prefix:
+
+#----------------------------------------
+# AzureStorageCache
+#----------------------------------------
+
+# !! Name of your Azure account.
+cantaloupe_AzureStorageCache_account_name:
+
+# !! Key of your Azure account.
+cantaloupe_AzureStorageCache_account_key:
+
+# !! Name of the container containing cached images.
+cantaloupe_AzureStorageCache_container_name:
+
+# !! String that will be prefixed to object keys.
+cantaloupe_AzureStorageCache_object_key_prefix:
+
+###########################################################################
+# OVERLAYS
+###########################################################################
+
+# Whether to enable overlays.
+cantaloupe_overlays_enabled: "false"
+
+# Specifies how overlays are configured. `BasicStrategy` will use the
+# `overlays.BasicStrategy.*` keys in this section. `ScriptStrategy` will
+# use the `overlay` delegate method. See the user manual for more
+# information.
+cantaloupe_overlays_strategy: BasicStrategy
+
+# `image` or `string`.
+cantaloupe_overlays_BasicStrategy_type: image
+
+# Absolute path or URL of the overlay image. Must be a PNG file.
+cantaloupe_overlays_BasicStrategy_image: /path/to/overlay.png
+
+# Overlay text.
+cantaloupe_overlays_BasicStrategy_string: Copyright \u00A9️ My Great Organization\nAll rights reserved.
+
+# For possible values, launch with the -Dcantaloupe.list_fonts option.
+cantaloupe_overlays_BasicStrategy_string_font: Helvetica
+
+# Font size in points.
+cantaloupe_overlays_BasicStrategy_string_font_size: 24
+
+# If the string doesn't fit in the image at the above size, the largest size
+# at which it does fit will be used, down to this.
+cantaloupe_overlays_BasicStrategy_string_font_min_size: 18
+
+# Font weight. 1 = regular, 2 = bold. Note that many fonts don't support
+# fractional weights.
+cantaloupe_overlays_BasicStrategy_string_font_weight: 1.0
+
+# Point spacing between glyphs, typically between -0.1 and 0.1.
+cantaloupe_overlays_BasicStrategy_string_glyph_spacing: 0.02
+
+# CSS color syntax is supported.
+cantaloupe_overlays_BasicStrategy_string_color: white
+
+# CSS color syntax is supported.
+cantaloupe_overlays_BasicStrategy_string_stroke_color: black
+
+# Stroke width in pixels.
+cantaloupe_overlays_BasicStrategy_string_stroke_width: 1
+
+# Color of a background to draw under the string.
+# CSS color syntax is supported.
+cantaloupe_overlays_BasicStrategy_string_background_color: rgba(0, 0, 0, 100)
+
+# Allowed values: `top left`, `top center`, `top right`, `left center`,
+# `center`, `right center`, `bottom left`, `bottom center`, `bottom right`.
+cantaloupe_overlays_BasicStrategy_position: bottom right
+
+# Pixel margin between the overlay and the image edge.
+cantaloupe_overlays_BasicStrategy_inset: 10
+
+# Output images less than this many pixels wide will not receive an overlay.
+# Set to 0 to add the overlay regardless.
+cantaloupe_overlays_BasicStrategy_output_width_threshold: 400
+
+# Output images less than this many pixels tall will not receive an overlay.
+# Set to 0 to add the overlay regardless.
+cantaloupe_overlays_BasicStrategy_output_height_threshold: 300
+
+###########################################################################
+# REDACTIONS
+###########################################################################
+
+# Whether to enable redactions. See the user manual for information about
+# how these work.
+cantaloupe_redaction_enabled: "false"
+
+###########################################################################
+# METADATA
+###########################################################################
+
+# Whether to attempt to copy source image metadata (EXIF, IPTC, XMP) into
+# derivative images. (This is not foolproof; see the user manual.)
+cantaloupe_metadata_preserve: "false"
+
+# Whether to respect the EXIF "Orientation" field to auto-rotate images.
+# The check for this field can impair performance slightly.
+cantaloupe_metadata_respect_orientation: "false"
+
+###########################################################################
+# LOGGING
+###########################################################################
+
+#----------------------------------------
+# Application Log
+#----------------------------------------
+
+# `trace`, `debug`, `info`, `warn`, `error`, `all`, or `off`
+cantaloupe_log_application_level: debug
+
+cantaloupe_log_application_ConsoleAppender_enabled: "true"
+
+cantaloupe_log_application_FileAppender_enabled: "false"
+cantaloupe_log_application_FileAppender_pathname: /path/to/logs/application.log
+
+# RollingFileAppender is an alternative to using something like
+# FileAppender + logrotate.
+cantaloupe_log_application_RollingFileAppender_enabled: "false"
+cantaloupe_log_application_RollingFileAppender_pathname: /path/to/logs/application.log
+cantaloupe_log_application_RollingFileAppender_policy: TimeBasedRollingPolicy
+cantaloupe_log_application_RollingFileAppender_TimeBasedRollingPolicy_filename_pattern: /path/to/logs/application-%d{yyyy-MM-dd}.log
+cantaloupe_log_application_RollingFileAppender_TimeBasedRollingPolicy_max_history: 30
+
+# See the "SyslogAppender" section for a list of facilities:
+# http://logback.qos.ch/manual/appenders.html
+cantaloupe_log_application_SyslogAppender_enabled: "false"
+cantaloupe_log_application_SyslogAppender_host:
+cantaloupe_log_application_SyslogAppender_port: 514
+cantaloupe_log_application_SyslogAppender_facility: LOCAL0
+
+#----------------------------------------
+# Access Log
+#----------------------------------------
+
+cantaloupe_log_access_ConsoleAppender_enabled: "false"
+
+cantaloupe_log_access_FileAppender_enabled: "false"
+cantaloupe_log_access_FileAppender_pathname: /path/to/logs/access.log
+
+# RollingFileAppender is an alternative to using something like
+# FileAppender + logrotate.
+cantaloupe_log_access_RollingFileAppender_enabled: "false"
+cantaloupe_log_access_RollingFileAppender_pathname: /path/to/logs/access.log
+cantaloupe_log_access_RollingFileAppender_policy: TimeBasedRollingPolicy
+cantaloupe_log_access_RollingFileAppender_TimeBasedRollingPolicy_filename_pattern: /path/to/logs/access-%d{yyyy-MM-dd}.log
+cantaloupe_log_access_RollingFileAppender_TimeBasedRollingPolicy_max_history: 30
+
+# See the "SyslogAppender" section for a list of facilities:
+# http://logback.qos.ch/manual/appenders.html
+cantaloupe_log_access_SyslogAppender_enabled: "false"
+cantaloupe_log_access_SyslogAppender_host:
+cantaloupe_log_access_SyslogAppender_port: 514
+cantaloupe_log_access_SyslogAppender_facility: LOCAL0

--- a/roles/internal/cantaloupe/tasks/cache.yml
+++ b/roles/internal/cantaloupe/tasks/cache.yml
@@ -1,0 +1,8 @@
+---
+
+- name: create cantaloupe cache dir
+  file:
+    state: directory
+    path: "{{ cantaloupe_FilesystemCache_pathname }}"
+    owner: "{{ cantaloupe_user }}"
+    group: "{{ cantaloupe_group }}"

--- a/roles/internal/cantaloupe/tasks/config.yml
+++ b/roles/internal/cantaloupe/tasks/config.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Template Cantaloupe Properties
+  template:
+    src: cantaloupe.properties.j2
+    dest:  "{{ cantaloupe_symlink }}/cantaloupe.properties"
+    owner: "{{ cantaloupe_user }}"
+    group: "{{ cantaloupe_group }}"

--- a/roles/internal/cantaloupe/tasks/install.yml
+++ b/roles/internal/cantaloupe/tasks/install.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Install Cantaloupe
+  unarchive:
+    remote_src: yes
+    src: https://github.com/medusa-project/cantaloupe/releases/download/v{{ cantaloupe_version }}/Cantaloupe-{{ cantaloupe_version }}.zip
+    dest: "{{ cantaloupe_install_root }}"
+    owner: "{{ cantaloupe_user }}"
+    group: "{{ cantaloupe_group }}"
+    creates: "{{ cantaloupe_install_root }}/Cantaloupe-{{ cantaloupe_version }}"
+
+- name: Create Cantaloupe symlink
+  file:
+    state: link
+    src: "{{ cantaloupe_install_root }}/Cantaloupe-{{ cantaloupe_version }}"
+    dest: "{{ cantaloupe_symlink }}"
+    owner: "{{ cantaloupe_user }}"
+    group: "{{ cantaloupe_group }}"
+
+- name: Create Cantaloupe log path
+  file:
+    state: directory
+    path: "{{ cantaloupe_log_path }}"
+    owner: "{{ cantaloupe_user }}"
+    group: "{{ cantaloupe_group }}"

--- a/roles/internal/cantaloupe/tasks/main.yml
+++ b/roles/internal/cantaloupe/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+
+- include: install.yml
+  tags:
+    - cantaloupe
+    - cantaloupe-install
+
+- include: config.yml
+  tags:
+    - cantaloupe
+    - cantaloupe-config
+
+- include: web.yml
+  tags:
+    - cantaloupe
+    - cantaloupe-web
+  when: cantaloupe_deploy_war
+
+- include: cache.yml
+  tags:
+    - cantaloupe
+    - cantaloupe-cache
+  when: cantaloupe_create_FilesystemCache_dir

--- a/roles/internal/cantaloupe/tasks/web.yml
+++ b/roles/internal/cantaloupe/tasks/web.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Install Cantaloupe web service
+  copy:
+    remote_src: yes
+    src: /opt/Cantaloupe-{{ cantaloupe_version }}/Cantaloupe-{{ cantaloupe_version }}.war
+    dest: "{{ cantaloupe_deploy_war_path }}/{{ cantaloupe_deploy_war_filename }}.war"
+    owner: "{{ cantaloupe_user }}"
+    group: "{{ cantaloupe_group }}"

--- a/roles/internal/cantaloupe/templates/cantaloupe.properties.j2
+++ b/roles/internal/cantaloupe/templates/cantaloupe.properties.j2
@@ -1,0 +1,315 @@
+###########################################################################
+# This file is managed by Ansible
+###########################################################################
+
+###########################################################################
+# GENERAL SETTINGS
+###########################################################################
+
+http.enabled = {{ cantaloupe_http_enabled }}
+http.host = {{ cantaloupe_http_host }}
+http.port = {{ cantaloupe_http_port }}
+https.enabled = {{ cantaloupe_https_enabled }}
+https.host = {{ cantaloupe_https_host }}
+https.port = {{ cantaloupe_https_port }}
+https.key_store_type = {{ cantaloupe_https_key_store_type }}
+https.key_store_password = {{ cantaloupe_https_key_store_password }}
+https.key_store_path = {{ cantaloupe_https_key_store_path }}
+https.key_password = {{ cantaloupe_https_key_password }}
+auth.basic.enabled = {{ cantaloupe_auth_basic_enabled }}
+auth.basic.username = {{ cantaloupe_auth_basic_username }}
+auth.basic.secret = {{ cantaloupe_auth_basic_secret }}
+admin.enabled = {{ cantaloupe_admin_enabled }}
+admin.password = {{ cantaloupe_admin_password }}
+base_uri = {{ cantaloupe_base_uri }}
+slash_substitute = {{ cantaloupe_slash_substitute }}
+max_pixels = {{ cantaloupe_max_pixels }}
+print_stack_trace_on_error_pages = {{ cantaloupe_print_stack_trace_on_error_pages }}
+
+###########################################################################
+# DELEGATE SCRIPT
+###########################################################################
+
+delegate_script.enabled = {{ cantaloupe_delegate_script_enabled }}
+delegate_script.pathname = {{ cantaloupe_delegate_script_pathname }}
+delegate_script.cache.enabled = {{ cantaloupe_delegate_script_cache_enabled }}
+
+###########################################################################
+# ENDPOINTS
+###########################################################################
+
+endpoint.iiif.1.enabled = {{ cantaloupe_endpoint_iiif_1_enabled }}
+endpoint.iiif.2.enabled = {{ cantaloupe_endpoint_iiif_2_enabled }}
+endpoint.iiif.content_disposition = {{ cantaloupe_endpoint_iiif_content_disposition }}
+endpoint.iiif.min_tile_size = {{ cantaloupe_endpoint_iiif_min_tile_size }}
+endpoint.iiif.2.restrict_to_sizes = {{ cantaloupe_endpoint_iiif_2_restrict_to_sizes }}
+endpoint.api.enabled = {{ cantaloupe_endpoint_api_enabled }}
+endpoint.api.username = {{ cantaloupe_endpoint_api_username }}
+endpoint.api.secret = {{ cantaloupe_endpoint_api_secret }}
+
+###########################################################################
+# RESOLVERS
+###########################################################################
+
+resolver.static = {{ cantaloupe_resolver_static }}
+resolver.delegate = {{ cantaloupe_resolver_delegate }}
+
+#----------------------------------------
+# FilesystemResolver
+#----------------------------------------
+
+FilesystemResolver.lookup_strategy = {{ cantaloupe_FilesystemResolver_lookup_strategy }}
+FilesystemResolver.BasicLookupStrategy.path_prefix = {{ cantaloupe_FilesystemResolver_BasicLookupStrategy_path_prefix }}
+FilesystemResolver.BasicLookupStrategy.path_suffix = {{ cantaloupe_FilesystemResolver_BasicLookupStrategy_path_suffix }}
+
+#----------------------------------------
+# HttpResolver
+#----------------------------------------
+
+HttpResolver.lookup_strategy = {{ cantaloupe_HttpResolver_lookup_strategy }}
+HttpResolver.BasicLookupStrategy.url_prefix = {{ cantaloupe_HttpResolver_BasicLookupStrategy_url_prefix }}
+HttpResolver.BasicLookupStrategy.url_suffix = {{ cantaloupe_HttpResolver_BasicLookupStrategy_url_suffix }}
+HttpResolver.auth.basic.username = {{ cantaloupe_HttpResolver_auth_basic_username }}
+HttpResolver.auth.basic.secret = {{ cantaloupe_HttpResolver_auth_basic_secret }}
+
+#----------------------------------------
+# JdbcResolver
+#----------------------------------------
+
+JdbcResolver.url = {{ cantaloupe_JdbcResolver_url }}
+JdbcResolver.user = {{ cantaloupe_JdbcResolver_user }}
+JdbcResolver.password = {{ cantaloupe_JdbcResolver_password }}
+JdbcResolver.connection_timeout = {{ cantaloupe_JdbcResolver_connection_timeout }}
+
+#----------------------------------------
+# AmazonS3Resolver
+#----------------------------------------
+
+AmazonS3Resolver.access_key_id = {{ cantaloupe_AmazonS3Resolver_access_key_id }}
+AmazonS3Resolver.secret_key = {{ cantaloupe_AmazonS3Resolver_secret_key }}
+AmazonS3Resolver.bucket.name = {{ cantaloupe_AmazonS3Resolver_bucket_name }}
+AmazonS3Resolver.bucket.region = {{ cantaloupe_AmazonS3Resolver_bucket_region }}
+AmazonS3Resolver.lookup_strategy = {{ cantaloupe_AmazonS3Resolver_lookup_strategy }}
+
+#----------------------------------------
+# AzureStorageResolver
+#----------------------------------------
+
+AzureStorageResolver.account_name = {{ cantaloupe_AzureStorageResolver_account_name }}
+AzureStorageResolver.account_key = {{ cantaloupe_AzureStorageResolver_account_key }}
+AzureStorageResolver.container_name = {{ cantaloupe_AzureStorageResolver_container_name }}
+AzureStorageResolver.lookup_strategy = {{ cantaloupe_AzureStorageResolver_lookup_strategy }}
+
+###########################################################################
+# PROCESSORS
+###########################################################################
+
+#----------------------------------------
+# Processor Selection
+#----------------------------------------
+
+processor.avi = {{ cantaloupe_processor_avi }}
+processor.bmp = {{ cantaloupe_processor_bmp }}
+processor.dcm = {{ cantaloupe_processor_dcm }}
+processor.gif = {{ cantaloupe_processor_gif }}
+processor.jp2 = {{ cantaloupe_processor_jp2 }}
+processor.jpg = {{ cantaloupe_processor_jpg }}
+processor.mov = {{ cantaloupe_processor_mov }}
+processor.mp4 = {{ cantaloupe_processor_mp4 }}
+processor.mpg = {{ cantaloupe_processor_mpg }}
+processor.pdf = {{ cantaloupe_processor_pdf }}
+processor.png = {{ cantaloupe_processor_png }}
+processor.tif = {{ cantaloupe_processor_tif }}
+processor.webm = {{ cantaloupe_processor_webm }}
+processor.webp = {{ cantaloupe_processor_webp }}
+processor.fallback = {{ cantaloupe_processor_fallback }}
+
+#----------------------------------------
+# Global Processor Configuration
+#----------------------------------------
+
+processor.normalize = {{ cantaloupe_processor_normalize }}
+processor.background_color = {{ cantaloupe_processor_background_color }}
+processor.downscale_filter = {{ cantaloupe_processor_downscale_filter }}
+processor.upscale_filter = {{ cantaloupe_processor_upscale_filter }}
+processor.sharpen = {{ cantaloupe_processor_sharpen }}
+processor.jpg.progressive = {{ cantaloupe_processor_jpg_progressive }}
+processor.jpg.quality = {{ cantaloupe_processor_jpg_quality }}
+processor.tif.compression = {{ cantaloupe_processor_tif_compression }}
+StreamProcessor.retrieval_strategy = {{ cantaloupe_StreamProcessor_retrieval_strategy }}
+
+#----------------------------------------
+# FfmpegProcessor
+#----------------------------------------
+
+FfmpegProcessor.path_to_binaries = {{ cantaloupe_FfmpegProcessor_path_to_binaries }}
+
+#----------------------------------------
+# GraphicsMagickProcessor
+#----------------------------------------
+
+GraphicsMagickProcessor.path_to_binaries = {{ cantaloupe_GraphicsMagickProcessor_path_to_binaries }}
+
+#----------------------------------------
+# ImageMagickProcessor
+#----------------------------------------
+
+ImageMagickProcessor.path_to_binaries = {{ cantaloupe_ImageMagickProcessor_path_to_binaries }}
+
+#----------------------------------------
+# KakaduProcessor
+#----------------------------------------
+
+KakaduProcessor.path_to_binaries = {{ cantaloupe_KakaduProcessor_path_to_binaries }}
+
+#----------------------------------------
+# OpenJpegProcessor
+#----------------------------------------
+
+OpenJpegProcessor.path_to_binaries = {{ cantaloupe_OpenJpegProcessor_path_to_binaries }}
+
+#----------------------------------------
+# PdfBoxProcessor
+#----------------------------------------
+
+PdfBoxProcessor.dpi = {{ cantaloupe_PdfBoxProcessor_dpi }}
+
+###########################################################################
+# CLIENT-SIDE CACHING
+###########################################################################
+
+cache.client.enabled = {{ cantaloupe_cache_client_enabled }}
+cache.client.max_age = {{ cantaloupe_cache_client_max_age }}
+cache.client.shared_max_age = {{ cantaloupe_cache_client_shared_max_age }}
+cache.client.public = {{ cantaloupe_cache_client_public }}
+cache.client.private = {{ cantaloupe_cache_client_private }}
+cache.client.no_cache = {{ cantaloupe_cache_client_no_cache }}
+cache.client.no_store = {{ cantaloupe_cache_client_no_store }}
+cache.client.must_revalidate = {{ cantaloupe_cache_client_must_revalidate }}
+cache.client.proxy_revalidate = {{ cantaloupe_cache_client_proxy_revalidate }}
+cache.client.no_transform = {{ cantaloupe_cache_client_no_transform }}
+
+###########################################################################
+# SERVER-SIDE CACHING
+###########################################################################
+
+cache.source = {{ cantaloupe_cache_source }}
+cache.derivative = {{ cantaloupe_cache_derivative }}
+cache.server.ttl_seconds = {{ cantaloupe_cache_server_ttl_seconds }}
+cache.server.purge_missing = {{ cantaloupe_cache_server_purge_missing }}
+cache.server.resolve_first = {{ cantaloupe_cache_server_resolve_first }}
+cache.server.worker.enabled = {{ cantaloupe_cache_server_worker_enabled }}
+cache.server.worker.interval = {{ cantaloupe_cache_server_worker_interval }}
+
+#----------------------------------------
+# FilesystemCache
+#----------------------------------------
+
+FilesystemCache.pathname = {{ cantaloupe_FilesystemCache_pathname }}
+FilesystemCache.dir.depth = {{ cantaloupe_FilesystemCache_dir_depth }}
+FilesystemCache.dir.name_length = {{ cantaloupe_FilesystemCache_dir_name_length }}
+
+#----------------------------------------
+# JdbcCache
+#----------------------------------------
+
+JdbcCache.url = {{ cantaloupe_JdbcCache_url }}
+JdbcCache.user = {{ cantaloupe_JdbcCache_user }}
+JdbcCache.password = {{ cantaloupe_JdbcCache_password }}
+JdbcCache.connection_timeout = {{ cantaloupe_JdbcCache_connection_timeout }}
+JdbcCache.derivative_image_table = {{ cantaloupe_JdbcCache_derivative_image_table }}
+JdbcCache.info_table = {{ cantaloupe_JdbcCache_info_table }}
+
+#----------------------------------------
+# AmazonS3Cache
+#----------------------------------------
+
+AmazonS3Cache.access_key_id = {{ cantaloupe_AmazonS3Cache_access_key_id }}
+AmazonS3Cache.secret_key = {{ cantaloupe_AmazonS3Cache_secret_key }}
+AmazonS3Cache.bucket.name = {{ cantaloupe_AmazonS3Cache_bucket_name }}
+AmazonS3Cache.bucket.region = {{ cantaloupe_AmazonS3Cache_bucket_region }}
+AmazonS3Cache.object_key_prefix = {{ cantaloupe_AmazonS3Cache_object_key_prefix }}
+
+#----------------------------------------
+# AzureStorageCache
+#----------------------------------------
+
+AzureStorageCache.account_name = {{ cantaloupe_AzureStorageCache_account_name }}
+AzureStorageCache.account_key = {{ cantaloupe_AzureStorageCache_account_key }}
+AzureStorageCache.container_name = {{ cantaloupe_AzureStorageCache_container_name }}
+AzureStorageCache.object_key_prefix = {{ cantaloupe_AzureStorageCache_object_key_prefix }}
+
+###########################################################################
+# OVERLAYS
+###########################################################################
+
+overlays.enabled = {{ cantaloupe_overlays_enabled }}
+overlays.strategy = {{ cantaloupe_overlays_strategy }}
+overlays.BasicStrategy.type = {{ cantaloupe_overlays_BasicStrategy_type }}
+overlays.BasicStrategy.image = {{ cantaloupe_overlays_BasicStrategy_image }}
+overlays.BasicStrategy.string = {{ cantaloupe_overlays_BasicStrategy_string }}
+overlays.BasicStrategy.string.font = {{ cantaloupe_overlays_BasicStrategy_string_font }}
+overlays.BasicStrategy.string.font.size = {{ cantaloupe_overlays_BasicStrategy_string_font_size }}
+overlays.BasicStrategy.string.font.min_size = {{ cantaloupe_overlays_BasicStrategy_string_font_min_size }}
+overlays.BasicStrategy.string.font.weight = {{ cantaloupe_overlays_BasicStrategy_string_font_weight }}
+overlays.BasicStrategy.string.glyph_spacing = {{ cantaloupe_overlays_BasicStrategy_string_glyph_spacing }}
+overlays.BasicStrategy.string.color = {{ cantaloupe_overlays_BasicStrategy_string_color }}
+overlays.BasicStrategy.string.stroke.color = {{ cantaloupe_overlays_BasicStrategy_string_stroke_color }}
+overlays.BasicStrategy.string.stroke.width = {{ cantaloupe_overlays_BasicStrategy_string_stroke_width }}
+overlays.BasicStrategy.string.background.color = {{ cantaloupe_overlays_BasicStrategy_string_background_color }}
+overlays.BasicStrategy.position = {{ cantaloupe_overlays_BasicStrategy_position }}
+overlays.BasicStrategy.inset = {{ cantaloupe_overlays_BasicStrategy_inset }}
+overlays.BasicStrategy.output_width_threshold = {{ cantaloupe_overlays_BasicStrategy_output_width_threshold }}
+overlays.BasicStrategy.output_height_threshold = {{ cantaloupe_overlays_BasicStrategy_output_height_threshold }}
+
+###########################################################################
+# REDACTIONS
+###########################################################################
+
+redaction.enabled = {{ cantaloupe_redaction_enabled }}
+
+###########################################################################
+# METADATA
+###########################################################################
+
+metadata.preserve = {{ cantaloupe_metadata_preserve }}
+metadata.respect_orientation = {{ cantaloupe_metadata_respect_orientation }}
+
+###########################################################################
+# LOGGING
+###########################################################################
+
+#----------------------------------------
+# Application Log
+#----------------------------------------
+
+log.application.level = {{ cantaloupe_log_application_level }}
+log.application.ConsoleAppender.enabled = {{ cantaloupe_log_application_ConsoleAppender_enabled }}
+log.application.FileAppender.enabled = {{ cantaloupe_log_application_FileAppender_enabled }}
+log.application.FileAppender.pathname = {{ cantaloupe_log_application_FileAppender_pathname }}
+log.application.RollingFileAppender.enabled = {{ cantaloupe_log_application_RollingFileAppender_enabled }}
+log.application.RollingFileAppender.pathname = {{ cantaloupe_log_application_RollingFileAppender_pathname }}
+log.application.RollingFileAppender.policy = {{ cantaloupe_log_application_RollingFileAppender_policy }}
+log.application.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = {{ cantaloupe_log_application_RollingFileAppender_TimeBasedRollingPolicy_filename_pattern }}
+log.application.RollingFileAppender.TimeBasedRollingPolicy.max_history = {{ cantaloupe_log_application_RollingFileAppender_TimeBasedRollingPolicy_max_history }}
+log.application.SyslogAppender.enabled = {{ cantaloupe_log_application_SyslogAppender_enabled }}
+log.application.SyslogAppender.host = {{ cantaloupe_log_application_SyslogAppender_host }}
+log.application.SyslogAppender.port = {{ cantaloupe_log_application_SyslogAppender_port }}
+log.application.SyslogAppender.facility = {{ cantaloupe_log_application_SyslogAppender_facility }}
+
+#----------------------------------------
+# Access Log
+#----------------------------------------
+
+log.access.ConsoleAppender.enabled = {{ cantaloupe_log_access_ConsoleAppender_enabled }}
+log.access.FileAppender.enabled = {{ cantaloupe_log_access_FileAppender_enabled }}
+log.access.FileAppender.pathname = {{ cantaloupe_log_access_FileAppender_pathname }}
+log.access.RollingFileAppender.enabled = {{ cantaloupe_log_access_RollingFileAppender_enabled }}
+log.access.RollingFileAppender.pathname = {{ cantaloupe_log_access_RollingFileAppender_pathname }}
+log.access.RollingFileAppender.policy = {{ cantaloupe_log_access_RollingFileAppender_policy }}
+log.access.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = {{ cantaloupe_log_access_RollingFileAppender_TimeBasedRollingPolicy_filename_pattern }}
+log.access.RollingFileAppender.TimeBasedRollingPolicy.max_history = {{ cantaloupe_log_access_RollingFileAppender_TimeBasedRollingPolicy_max_history }}x
+log.access.SyslogAppender.enabled = {{ cantaloupe_log_access_SyslogAppender_enabled }}
+log.access.SyslogAppender.host = {{ cantaloupe_log_access_SyslogAppender_host }}
+log.access.SyslogAppender.port = {{ cantaloupe_log_access_SyslogAppender_port }}
+log.access.SyslogAppender.facility = {{ cantaloupe_log_access_SyslogAppender_facility }}

--- a/roles/internal/openjpeg/tasks/install.yml
+++ b/roles/internal/openjpeg/tasks/install.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Install OpenJPEG
+  apt:
+    pkg: libopenjp2-tools
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600

--- a/roles/internal/openjpeg/tasks/main.yml
+++ b/roles/internal/openjpeg/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+  - include: install.yml
+    tags:
+      - openjpeg
+      - openjpeg-install

--- a/tomcat.yml
+++ b/tomcat.yml
@@ -9,3 +9,5 @@
     - fcrepo
     - fcrepo-syn
     - blazegraph
+    - openjpeg
+    - cantaloupe


### PR DESCRIPTION
## Ticket
Resolves: https://github.com/Islandora-CLAW/CLAW/issues/694

## Caveats 
Doesn't include any configuration for openseadragon, as the original shell script does. I'm going to punt this to https://github.com/Islandora-CLAW/CLAW/issues/693, since that configuration can't be set until that module is installed.

Relevant line here:
https://github.com/Islandora-CLAW/claw_vagrant/blob/master/scripts/cantaloupe.sh#L35

## Testing

- Checkout this patch
- Provision just cantaloupe and tomcat:

```bash
$ vagrant up --no-provision
$ ansible-playbook -i inventory/vagrant bootstrap.yml
$ ansible-playbook -i inventory/vagrant playbook.yml --tags cantaloupe,tomcat8,openjpeg
$ vagrant ssh
$ mkdir -p /var/www/html/drupal/web/
```

- Put test images in `/var/www/html/drupal/web` (tiff, jp2, etc)
- Check that you can see them at: `http://localhost:8080/cantaloupe/iiif/2/FILE.NAME/full/full/0/default.jpg`
- Check logs at: `/var/log/cantaloupe`