### PR TITLE
Add postgresql

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -3,5 +3,13 @@
 - hosts: database
   become: yes
 
+  pre_tasks:
+    - set_fact:
+        claw_db: 'mysql'
+      when: claw_db is not defined
+
   roles:
-    - mysql
+    - role: mysql
+      when: claw_db == 'mysql'
+    - role: postgresql
+      when: claw_db == 'pgsql'

--- a/inventory/vagrant/group_vars/all.yml
+++ b/inventory/vagrant/group_vars/all.yml
@@ -10,3 +10,5 @@ islandora_extra_packages:
   - unzip
   - build-essential
   - vim
+
+postgresql_user: postgres

--- a/inventory/vagrant/group_vars/database.yml
+++ b/inventory/vagrant/group_vars/database.yml
@@ -1,2 +1,10 @@
 mysql_root_username: root
 mysql_root_password: islandora
+
+postgresql_users:
+  - name: root
+    password: islandora
+    db: "{{ drupal_db_name }}"
+
+postgresql_databases:
+  - name: "{{ drupal_db_name }}"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -9,7 +9,7 @@ drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: root
 drupal_db_password: islandora
 drupal_db_name: drupal8
-drupal_db_backend: mysql
+drupal_db_backend: "{{ claw_db }}"
 drupal_db_host: "127.0.0.1"
 drupal_domain: "claw.dev"
 drupal_site_name: "Islandora-CLAW"

--- a/inventory/vagrant/group_vars/webserver/php.yml
+++ b/inventory/vagrant/group_vars/webserver/php.yml
@@ -4,3 +4,4 @@ php_date_timezone: "America/Toronto"
 php_packages_extra:
   - libapache2-mod-php7.0
   - php7.0-mysql
+  - php7.0-pgsql

--- a/requirements.yml
+++ b/requirements.yml
@@ -18,6 +18,10 @@
   name: mysql
   version: 2.7.2
 
+- src: geerlingguy.postgresql
+  name: postgresql
+  version: 1.3.1
+
 - src: geerlingguy.solr
   name: solr
   version: 3.5.5


### PR DESCRIPTION
## Ticket
https://github.com/Islandora-CLAW/CLAW/issues/695

## What it does

This lets you bring up this stack with postgresql by passing a variable. This could be done in an inventory. The easiest way for testing is probably on the command line with the `--extra-vars` flag. 

This probably needs more work as other things using DB are added to the playbook, but I wanted to get a start on it. 

## Testing

```
$ vagrant up --no-provision
$ ansible-playbook -i inventory/vagrant playbook.yml --extra-vars="claw_db=pgsql"
```

Make sure postgresql is being used by drupal instead of mysql.