### PR TITLE
activemq

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 3306, host: 3306 # MySQL
   config.vm.network :forwarded_port, guest: 5432, host: 5432 # PostgreSQL
   config.vm.network :forwarded_port, guest: 8983, host: 8983 # Solr
+  config.vm.network :forwarded_port, guest: 8161, host: 8161 # Activemq
 
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", $memory]

--- a/roles/internal/activemq/defaults/main.yml
+++ b/roles/internal/activemq/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+
+activemq_download_dir: /usr/local/src
+activemq_version: 5.14.5
+activemq_install_root: /opt
+activemq_install_symlink: /opt/activemq
+activemq_user: ubuntu
+activemq_group: ubuntu
+

--- a/roles/internal/activemq/defaults/main.yml
+++ b/roles/internal/activemq/defaults/main.yml
@@ -1,9 +1,7 @@
 ---
 
-activemq_download_dir: /usr/local/src
 activemq_version: 5.14.5
 activemq_install_root: /opt
-activemq_install_symlink: /opt/activemq
 activemq_user: ubuntu
 activemq_group: ubuntu
 

--- a/roles/internal/activemq/meta/main.yml
+++ b/roles/internal/activemq/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  description: "Installs Activemq"
+  license: "license (GPLv3)"
+  min_ansible_version: 2.0
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Ubuntu
+      versions:
+        - trusty
+        - utopic
+  galaxy_tags:
+    - message:queues
+    - messaging
+dependencies: []

--- a/roles/internal/activemq/tasks/install.yml
+++ b/roles/internal/activemq/tasks/install.yml
@@ -1,8 +1,4 @@
 ---
-- name: Clean activemq path
-  file:
-    state: absent
-    path: "{{ activemq_install_root }}/activemq"
 
 - name: Download and unarchive activemq
   unarchive:
@@ -11,18 +7,18 @@
     dest: "{{ activemq_install_root }}"
     owner: "{{ activemq_user }}"
     group: "{{ activemq_group }}"
+    creates: "{{ activemq_install_root }}/activemq"
 
 - name: Move activemq
   command: mv "{{ activemq_install_root }}/apache-activemq-{{ activemq_version }}" "{{ activemq_install_root }}/activemq"
+  args:
+    creates: "{{ activemq_install_root }}/activemq"
 
 - name: Create symlink
   file:
     state: link
     src: "/opt/activemq/bin/activemq"
     dest: "/etc/init.d/activemq"
-
-- name: Add activemq service to start up
-  shell: 'update-rc.d activemq defaults'
 
 - name: Start activeMQ service
   service:

--- a/roles/internal/activemq/tasks/install.yml
+++ b/roles/internal/activemq/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Download and unarchive activemq
+- name: Download and unarchive
   unarchive:
     remote_src: yes
     src: http://archive.apache.org/dist/activemq/{{ activemq_version }}/apache-activemq-{{ activemq_version }}-bin.tar.gz
@@ -20,8 +20,9 @@
     src: "/opt/activemq/bin/activemq"
     dest: "/etc/init.d/activemq"
 
-- name: Start activeMQ service
-  service:
+- name: Reload systemd
+  systemd:
+    daemon-reload: yes
+    enabled: yes
     state: started
     name: activemq
-    enabled: yes

--- a/roles/internal/activemq/tasks/install.yml
+++ b/roles/internal/activemq/tasks/install.yml
@@ -1,0 +1,31 @@
+---
+- name: Clean activemq path
+  file:
+    state: absent
+    path: "{{ activemq_install_root }}/activemq"
+
+- name: Download and unarchive activemq
+  unarchive:
+    remote_src: yes
+    src: http://archive.apache.org/dist/activemq/{{ activemq_version }}/apache-activemq-{{ activemq_version }}-bin.tar.gz
+    dest: "{{ activemq_install_root }}"
+    owner: "{{ activemq_user }}"
+    group: "{{ activemq_group }}"
+
+- name: Move activemq
+  command: mv "{{ activemq_install_root }}/apache-activemq-{{ activemq_version }}" "{{ activemq_install_root }}/activemq"
+
+- name: Create symlink
+  file:
+    state: link
+    src: "/opt/activemq/bin/activemq"
+    dest: "/etc/init.d/activemq"
+
+- name: Add activemq service to start up
+  shell: 'update-rc.d activemq defaults'
+
+- name: Start activeMQ service
+  service:
+    state: started
+    name: activemq
+    enabled: yes

--- a/roles/internal/activemq/tasks/main.yml
+++ b/roles/internal/activemq/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- include: install.yml
+  tags:
+    - activemq
+    - activemq-install
+

--- a/tomcat.yml
+++ b/tomcat.yml
@@ -11,3 +11,4 @@
     - blazegraph
     - grok
     - cantaloupe
+    - activemq


### PR DESCRIPTION
## Ticket 
https://github.com/Islandora-CLAW/CLAW/issues/690

## What it does
Adds a role to install activemq.  Implements the  [activemq.sh](https://github.com/Islandora-CLAW/claw_vagrant/blob/master/scripts/activemq.sh) logic in Ansible.

## Testing
* Get PR and vagrant up
* Go to http://localhost:8161/admin (admin:admin), verify Activemq is up and running

If you already have a claw-playbook provisioned: 
```
vagrant up --no-provision
ansible-playbook -i inventory/vagrant/hosts  playbook.yml --tags activemq
```