### PR TITLE
Use Drupal JWT keys in Syn too

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -27,7 +27,7 @@ fcrepo_syn_sites:
     encoding: PEM
     anonymous: true
     default: true
-    path: /home/ubuntu/auth/public.key
+    path: "{{ webserver_app_jwt_key_path }}/public.key"
 
 fcrepo_syn_tokens:
   - user: admin

--- a/inventory/vagrant/group_vars/webserver/general.yml
+++ b/inventory/vagrant/group_vars/webserver/general.yml
@@ -3,3 +3,5 @@
 webserver_app: yes
 openseadragon_iiiv_set_var: yes
 openseadragon_iiiv_server: http://localhost:8080/cantaloupe/iiif/2
+webserver_app_jwt_key_path: /home/ubuntu/auth
+


### PR DESCRIPTION
Simply Resolves https://github.com/Islandora-CLAW/CLAW/issues/702

This is very basic and only good for single server setups.

It will need more to do actual copying of a JWT if Fedora and Drupal are on separate machines.