### PR TITLE
Add activemq config for fcrepo

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -17,6 +17,7 @@ tomcat8_java_opts:
   - -XX:PermSize=256m
   - -XX:MaxPermSize=256m
   - -Dfcrepo.modeshape.configuration=file://{{ fcrepo_home_dir }}/configs/repository.json
+  - -Dfcrepo.activemq.configuration=file://{{ fcrepo_config_dir }}/activemq.xml
   - -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile={{ blazegraph_home_dir }}/conf/RWStore.properties
   - -Dcantaloupe.config={{ cantaloupe_symlink }}/cantaloupe.properties
   - -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

--- a/roles/internal/fcrepo/defaults/main.yml
+++ b/roles/internal/fcrepo/defaults/main.yml
@@ -4,4 +4,4 @@ fcrepo_data_dir: /var/lib/tomcat8/fcrepo4-data
 fcrepo_war_path: "{{ tomcat8_home }}/webapps/fcrepo.war"
 fcrepo_home_dir: /opt/fcrepo
 fcrepo_activemq_template: activemq.xml.j2
-fcrepo_tomcat_config_dir: "{{ tomcat8_home }}/webapps/fcrepo/WEB-INF/classes/config/"
+fcrepo_config_dir: "{{ fcrepo_home_dir }}/configs"

--- a/roles/internal/fcrepo/defaults/main.yml
+++ b/roles/internal/fcrepo/defaults/main.yml
@@ -3,3 +3,5 @@ fcrepo_user: tomcat8
 fcrepo_data_dir: /var/lib/tomcat8/fcrepo4-data
 fcrepo_war_path: "{{ tomcat8_home }}/webapps/fcrepo.war"
 fcrepo_home_dir: /opt/fcrepo
+fcrepo_activemq_template: activemq.xml.j2
+fcrepo_tomcat_config_dir: "{{ tomcat8_home }}/webapps/fcrepo/WEB-INF/classes/config/"

--- a/roles/internal/fcrepo/tasks/config.yml
+++ b/roles/internal/fcrepo/tasks/config.yml
@@ -7,3 +7,17 @@
   with_items:
     - claw.cnd
     - repository.json
+  notify: restart tomcat8
+
+- name: Wait for fcrepo to expand
+  wait_for:
+    path: "{{ fcrepo_tomcat_config_dir }}"
+    state: present
+
+- name: Copy fedora activemq configuration
+  template:
+    src: "{{ fcrepo_activemq_template }}"
+    dest: "{{ fcrepo_tomcat_config_dir }}/activemq.xml"
+    owner: "{{ fcrepo_user }}"
+    group: "{{ fcrepo_user }}"
+  notify: restart tomcat8

--- a/roles/internal/fcrepo/tasks/config.yml
+++ b/roles/internal/fcrepo/tasks/config.yml
@@ -9,15 +9,10 @@
     - repository.json
   notify: restart tomcat8
 
-- name: Wait for fcrepo to expand
-  wait_for:
-    path: "{{ fcrepo_tomcat_config_dir }}"
-    state: present
-
 - name: Copy fedora activemq configuration
   template:
     src: "{{ fcrepo_activemq_template }}"
-    dest: "{{ fcrepo_tomcat_config_dir }}/activemq.xml"
+    dest: "{{ fcrepo_config_dir }}/activemq.xml"
     owner: "{{ fcrepo_user }}"
     group: "{{ fcrepo_user }}"
   notify: restart tomcat8

--- a/roles/internal/fcrepo/tasks/install.yml
+++ b/roles/internal/fcrepo/tasks/install.yml
@@ -21,7 +21,7 @@
 
 - name: Create fcrepo config directory
   file:
-    path: "{{ fcrepo_home_dir }}/configs"
+    path: "{{ fcrepo_config_dir }}"
     state: directory
     owner: "{{ fcrepo_user }}"
     group: "{{ fcrepo_user }}"

--- a/roles/internal/fcrepo/templates/activemq.xml.j2
+++ b/roles/internal/fcrepo/templates/activemq.xml.j2
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:amq="http://activemq.apache.org/schema/core"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+    http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <context:property-placeholder/>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost">
+      <persistenceAdapter>
+        <kahaDB directory="${fcrepo.activemq.directory:ActiveMQ/kahadb}"/>
+      </persistenceAdapter>
+      <networkConnectors>
+        <networkConnector name="fedora_bridge" dynamicOnly="true" uri="static:(tcp://localhost:61616)">
+          <dynamicallyIncludedDestinations>
+            <topic physicalName="fedora"/>
+            <queue physicalName="fedora"/>
+          </dynamicallyIncludedDestinations>
+        </networkConnector>
+      </networkConnectors>
+    </broker>
+</beans>


### PR DESCRIPTION
## Ticket
https://github.com/Islandora-CLAW/CLAW/issues/711

## Issue
Fcrepo wasn't coming up because of two activemq, embedded and external. Same fix as for the vagrant box we need to configure fedora to not start activemq broker.

## Testcase
Run playbook and make sure fcrepo comes up.