### PR TITLE
Update playbook to deploy Gemini with Postgresql

### DIFF
--- a/inventory/vagrant/group_vars/crayfish.yml
+++ b/inventory/vagrant/group_vars/crayfish.yml
@@ -1,0 +1,3 @@
+---
+
+crayfish_db: "{{ claw_db }}"

--- a/roles/internal/crayfish/defaults/main.yml
+++ b/roles/internal/crayfish/defaults/main.yml
@@ -9,6 +9,15 @@ crayfish_services:
 
 crayfish_syn_token: islandora
 
+# possible options: mysql, pgsql
+crayfish_db: mysql
+crayfish_pgsql_user: postgres
+crayfish_db_user: crayfish
+crayfish_db_password: islandora
+crayfish_db_name: gemini
+crayfish_db_driver: "{% if crayfish_db == 'mysql' %}pdo_mysql{% elif crayfish_db == 'pgsql' %}pdo_pgsql{% endif %}"
+crayfish_db_port: "{% if crayfish_db == 'mysql' %}3306{% elif crayfish_db == 'pgsql' %}5432{% endif %}"
+
 # Gemini default config
 crayfish_gemini_log_file: /var/log/islandora/gemini.log
 crayfish_gemini_log_level: DEBUG
@@ -17,13 +26,13 @@ crayfish_gemini_jwt_enabled: TRUE
 crayfish_gemini_jwt_config: ../syn-settings.xml
 
 crayfish_gemini_db_options:
-  driver: pdo_mysql
+  driver: "{{ crayfish_db_driver }}"
   host: 127.0.0.1
-  port: 3306
-  dbname: gemini
-  user: root
-  password: islandora
-  
+  port: "{{ crayfish_db_port }}"
+  dbname: "{{ crayfish_db_name }}"
+  user: "{{ crayfish_db_user }}"
+  password: "{{ crayfish_db_password }}"
+
 # Houdini default config
 crayfish_houdini_log_file: /var/log/islandora/houdini.log
 crayfish_houdini_log_level: DEBUG
@@ -42,7 +51,7 @@ crayfish_houdini_executable_config:
       - image/tiff
       - image/jp2
     default: image/jpeg
-    
+
 # Hypercube default config
 crayfish_hypercube_log_file: /var/log/islandora/hypercube.log
 crayfish_hypercube_log_level: DEBUG
@@ -64,10 +73,10 @@ crayfish_milliner_fedora_base_url: http://localhost:8080/fcrepo/rest
 crayfish_milliner_drupal_base_url: http://localhost:8000
 
 crayfish_milliner_db_options:
-  driver: pdo_mysql
+  driver: "{{ crayfish_db_driver }}"
   host: 127.0.0.1
-  port: 3306
-  dbname: gemini
-  user: root
-  password: islandora
+  port: "{{ crayfish_db_port }}"
+  dbname: "{{ crayfish_db_name }}"
+  user: "{{ crayfish_db_user }}"
+  password: "{{ crayfish_db_password }}"
 

--- a/roles/internal/crayfish/defaults/main.yml
+++ b/roles/internal/crayfish/defaults/main.yml
@@ -1,5 +1,5 @@
 crayfish_user: www-data
-crayfish_version_tag: 0.0.6
+crayfish_version_tag: 0.0.7
 
 crayfish_services:
   - Gemini

--- a/roles/internal/crayfish/tasks/db-mysql.yml
+++ b/roles/internal/crayfish/tasks/db-mysql.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Create Gemini DB (mysql)
+  mysql_db:
+    name: "{{ crayfish_db_name }}"
+    state: present
+  register: gemini_db_exists
+
+- name: Create Gemini DB User (mysql)
+  mysql_user:
+    name: "{{ crayfish_db_user }}"
+    password: "{{ crayfish_db_password }}"
+    state: present
+    priv: "{{crayfish_db_name}}.*:ALL"
+
+- name: Grab Gemini db schema (mysql)
+  template:
+    src: "gemini.sql"
+    dest: "/tmp/gemini.sql"
+  when: gemini_db_exists.changed
+
+- name: Install Gemini db schema (mysql)
+  mysql_db:
+    state: import
+    name: all
+    target: "/tmp/gemini.sql"
+  when: gemini_db_exists.changed

--- a/roles/internal/crayfish/tasks/db-pgsql.yml
+++ b/roles/internal/crayfish/tasks/db-pgsql.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Create Gemini DB User (pgsql)
+  postgresql_user:
+    name: "{{ crayfish_db_user }}"
+    password: "{{ crayfish_db_password }}"
+
+- name: Create Gemini DB (pgsql)
+  postgresql_db:
+    name: "{{ crayfish_db_name }}"
+    state: present
+    owner: "{{ crayfish_db_user }}"
+  register: gemini_db_exists
+
+- name: Grab Gemini db schema (pgsql)
+  template:
+    src: "database/gemini-pgsql.sql"
+    dest: "/tmp/gemini.sql"
+  when: gemini_db_exists.changed
+
+- name: Install Gemini db schema (pgsql)
+  command: psql -d {{ crayfish_db_name }} -f /tmp/gemini.sql
+  when: gemini_db_exists.changed

--- a/roles/internal/crayfish/tasks/install.yml
+++ b/roles/internal/crayfish/tasks/install.yml
@@ -17,44 +17,25 @@
     repo: https://github.com/Islandora-CLAW/Crayfish.git
     dest: "/var/www/html/Crayfish"
     version: "{{ crayfish_version_tag }}"
-    
+
 - name: Build crayfish code including dependencies
   composer:
     command: install
     working_dir: /var/www/html/Crayfish/{{item}}
   with_items: "{{ crayfish_services }}"
-    
+
 - name: Configure crayfish code
   template:
     src: "{{item}}.config.yaml.j2"
     dest: "/var/www/html/Crayfish/{{item}}/cfg/config.yaml"
   with_items: "{{ crayfish_services }}"
-    
+
 - name: Install auth config
   template:
     src: "syn-settings.xml.jp2"
     dest: "/var/www/html/Crayfish/{{item}}/syn-settings.xml"
   with_items: "{{ crayfish_services }}"
 
-- name: Create Gemini db
-  mysql_db:
-    name: "{{ crayfish_gemini_db_options.dbname }}"
-    state: present
-  register: gemini_db_exists
-
-- name: Grab Gemini db schema
-  template:
-    src: "gemini.sql"
-    dest: "/tmp/gemini.sql"
-  when: gemini_db_exists.changed
-
-- name: Install Gemini db schema
-  mysql_db:
-    state: import
-    name: all
-    target: "/tmp/gemini.sql"
-  when: gemini_db_exists.changed
-    
 - name: Create Islandora log dir
   file:
     path: /var/log/islandora

--- a/roles/internal/crayfish/tasks/main.yml
+++ b/roles/internal/crayfish/tasks/main.yml
@@ -1,2 +1,19 @@
+---
+
+- include: db-mysql.yml
+  tags:
+    - crayfish
+    - crayfish-db
+  when: crayfish_db == 'mysql'
+
+- include: db-pgsql.yml
+  tags:
+    - crayfish
+    - crayfish-db
+  when: crayfish_db == 'pgsql'
+  become_user: "{{ crayfish_pgsql_user }}"
+
 - include: install.yml
-  tags: crayfish
+  tags:
+    - crayfish
+    - crayfish-install

--- a/roles/internal/crayfish/templates/database/gemini-mysql.sql
+++ b/roles/internal/crayfish/templates/database/gemini-mysql.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS {{ crayfish_gemini_db_options.dbname }}.Gemini (
+CREATE TABLE IF NOT EXISTS {{ crayfish_db_name }}.Gemini (
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     drupal VARCHAR(2048) NOT NULL UNIQUE,
     fedora VARCHAR(2048) NOT NULL UNIQUE

--- a/roles/internal/crayfish/templates/database/gemini-pgsql.sql
+++ b/roles/internal/crayfish/templates/database/gemini-pgsql.sql
@@ -1,0 +1,6 @@
+CREATE TABLE Gemini (
+    id SERIAL PRIMARY KEY,
+    drupal VARCHAR(2048) NOT NULL UNIQUE,
+    fedora VARCHAR(2048) NOT NULL UNIQUE
+);
+ALTER TABLE Gemini OWNER TO {{ crayfish_db_user }};


### PR DESCRIPTION
## Details

This lets us deploy crayfish using Postgres instead of MySQL, as we can with drupal in the playbook. 

## Testing

- Test that both Postgres and mysql work:
- Postgres:
  - `vagrant up --no-provision`
  - `ansible-playbook -i inventory/vagrant playbook.yml --extra-vars="claw_db=pgsql"`
  - make sure things with with Postgres, especially gemini
- For completeness: `vagrant destroy`
- MySQL: 
  - `vagrant up --no-provision`
  - `ansible-playbook -i inventory/vagrant playbook.yml --extra-vars="claw_db=mysql"`
  - make sure things with with mysql