### PR TITLE
Use snapshots instead of compiling by default

### DIFF
--- a/roles/internal/alpaca/defaults/main.yml
+++ b/roles/internal/alpaca/defaults/main.yml
@@ -1,11 +1,12 @@
 ---
 
-alpaca_from_source: yes
+alpaca_from_source: no
 
 alpaca_version: master
 alpaca_clone_directory: /opt/alpaca
 
-alpaca_karaf_repos: []
+alpaca_karaf_repos:
+  - mvn:ca.islandora.alpaca/islandora-karaf/LATEST/xml/features
 
 alpaca_features:
   - islandora-http-client


### PR DESCRIPTION
## Github issue

Related to: 
https://github.com/Islandora-CLAW/Alpaca/pull/45

Issue: 
https://github.com/Islandora-CLAW/CLAW/issues/713

## Changes

Instead of compiling Alpaca by default, just bring up the box with the snapshot.

## Testing

Bring up box and make sure everything still works, and that Alpaca comes out of snapshots in maven.