### PR TITLE
Enable profiling in Ansible

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 host_key_checking = false
 roles_path = roles/internal:roles/external
+callback_whitelist = profile_tasks


### PR DESCRIPTION
This PR adds a line to the Ansible config to enable profiling. Gives some interesting data that might help us reduce the time it takes to start things up eventually. 

Gives a nice summary like this after the playbook is run:
```
Thursday 21 September 2017  10:56:35 -0300 (0:00:02.065)       0:20:59.319 **** 
=============================================================================== 
drupal : Install dependencies with composer require. ------------------ 196.72s
drupal : Generate Drupal project with composer package. --------------- 161.62s
grok : Make grok ------------------------------------------------------- 98.60s
alpaca : Add Alpaca Features ------------------------------------------- 98.56s
php : Ensure PHP packages are installed. ------------------------------- 55.50s
apix : Add API-X Features ---------------------------------------------- 37.45s
java : Ensure Java is installed. --------------------------------------- 37.43s
crayfish : Build crayfish code including dependencies ------------------ 36.29s
install extra packages ------------------------------------------------- 24.92s
tomcat8 : install tomcat8 ---------------------------------------------- 24.34s
mysql : Ensure MySQL packages are installed. --------------------------- 22.25s
solr : Download Solr. -------------------------------------------------- 20.06s
openseadragon : Install Openseadragon with composer -------------------- 19.71s
tomcat8 : tomcat8 restart tomcat8 -------------------------------------- 18.90s
crayfish : Install requisite packages ---------------------------------- 16.94s
drupal : Install Drupal with drush. ------------------------------------ 15.49s
solr : Run Solr installation script. ----------------------------------- 14.85s
install aptitude ------------------------------------------------------- 13.81s
drupal : Install configured modules with drush. ------------------------ 13.14s
blazegraph : Download blazegraph war ----------------------------------- 12.66s
```