### PR TITLE
Fix incorrect path for MySQL SQL file.

### DIFF
--- a/roles/internal/crayfish/tasks/db-mysql.yml
+++ b/roles/internal/crayfish/tasks/db-mysql.yml
@@ -15,7 +15,7 @@
 
 - name: Grab Gemini db schema (mysql)
   template:
-    src: "gemini.sql"
+    src: "database/gemini-mysql.sql"
     dest: "/tmp/gemini.sql"
   when: gemini_db_exists.changed
 


### PR DESCRIPTION
## Reason for PR

In https://github.com/Islandora-Devops/claw-playbook/pull/14 it looks like I broke the path for the MySQL sql file, so postgresql is working in the playbook but not mysql. Issue found by @whikloj.

## Testing

Run playbook and make sure gemini sets up its MySQL database correctly.

