### PR TITLE
add drupal solr related tasks

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -44,6 +44,9 @@ drupal_enable_modules:
   - islandora
   - islandora_collection
   - islandora_image
+  - search_api_solr
+  - search_api_solr_defaults
+  - facets
 drupal_trusted_hosts:
   - ^localhost$
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,8 +2,8 @@
 
 - include: bootstrap.yml
 - include: database.yml
+- include: solr.yml
 - include: webserver.yml
 - include: tomcat.yml
-- include: solr.yml
 - include: crayfish.yml
 - include: karaf.yml

--- a/roles/internal/webserver-app/defaults/main.yml
+++ b/roles/internal/webserver-app/defaults/main.yml
@@ -10,3 +10,4 @@ webserver_app_jwt_config_path: /home/ubuntu/configs/jwt
 webserver_app_drupal_config_path: /home/ubuntu/configs/drupal
 
 webserver_app_user: ubuntu
+solr_user: solr

--- a/roles/internal/webserver-app/defaults/main.yml
+++ b/roles/internal/webserver-app/defaults/main.yml
@@ -11,3 +11,6 @@ webserver_app_drupal_config_path: /home/ubuntu/configs/drupal
 
 webserver_app_user: ubuntu
 solr_user: solr
+solr_instance_conf_path: /var/solr/data/CLAW/conf
+
+webserver_document_root: /var/www/html

--- a/roles/internal/webserver-app/meta/main.yml
+++ b/roles/internal/webserver-app/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- role: solr

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -104,3 +104,4 @@
     remote_src: True
   with_items:
    - "{{ files_to_copy.stdout_lines }}"
+  notify: restart solr

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -62,3 +62,45 @@
   args:
     chdir: "{{ drupal_core_path }}"
   when: drupal_member_block.changed is defined and drupal_member_block.changed
+
+- name: Enable drupal module search_api_solr
+  command: drush en -y search_api_solr
+  args:
+    chdir: "{{ drupal_core_path }}"
+  register: install_search_api_solr
+  changed_when: "'enabled successfully' in install_search_api_solr.stdout"
+
+- name: Enable drupal module search_api_solr_defaults
+  command: drush en -y search_api_solr_defaults
+  args:
+    chdir: "{{ drupal_core_path }}"
+  register: install_search_api_solr_defaults
+  changed_when: "'enabled successfully' in install_search_api_solr_defaults.stdout"
+
+- name: Set default solr server to point to CLAW core
+  command: drush -y config-set search_api.server.default_solr_server backend_config.connector_config.core CLAW
+  args:
+    chdir: "{{ drupal_core_path }}"
+  register: set_search_api_config
+  changed_when: "'Do you want to update' in set_search_api_config.stdout"
+
+- name: Enable drupal module facets
+  command: drush en -y facets
+  args:
+    chdir: "{{ drupal_core_path }}"
+  register: install_facets
+  changed_when: "'enabled successfully' in install_facets.stdout"
+
+- name: Get solr config files to copy
+  command: "find /var/www/html/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x -type f"
+  register: files_to_copy
+
+- name: Copy solr config files
+  copy:
+    src: "{{ item }}"
+    dest: "/var/solr/data/CLAW/conf"
+    owner: "{{ solr_user }}"
+    group: "{{ solr_user }}"
+    remote_src: True
+  with_items:
+   - "{{ files_to_copy.stdout_lines }}"

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -71,14 +71,14 @@
   changed_when: "'Do you want to update' in set_search_api_config.stdout"
 
 - name: Get solr config files to copy
-  command: "find /var/www/html/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x -type f"
+  command: "find {{ webserver_document_root }}/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x -type f"
   register: files_to_copy
   changed_when: false
 
 - name: Copy solr config files
   copy:
     src: "{{ item }}"
-    dest: "/var/solr/data/CLAW/conf"
+    dest: "{{ solr_instance_conf_path }}"
     owner: "{{ solr_user }}"
     group: "{{ solr_user }}"
     remote_src: True

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -63,20 +63,6 @@
     chdir: "{{ drupal_core_path }}"
   when: drupal_member_block.changed is defined and drupal_member_block.changed
 
-- name: Enable drupal module search_api_solr
-  command: drush en -y search_api_solr
-  args:
-    chdir: "{{ drupal_core_path }}"
-  register: install_search_api_solr
-  changed_when: "'enabled successfully' in install_search_api_solr.stdout"
-
-- name: Enable drupal module search_api_solr_defaults
-  command: drush en -y search_api_solr_defaults
-  args:
-    chdir: "{{ drupal_core_path }}"
-  register: install_search_api_solr_defaults
-  changed_when: "'enabled successfully' in install_search_api_solr_defaults.stdout"
-
 - name: Set default solr server to point to CLAW core
   command: drush -y config-set search_api.server.default_solr_server backend_config.connector_config.core CLAW
   args:
@@ -84,16 +70,10 @@
   register: set_search_api_config
   changed_when: "'Do you want to update' in set_search_api_config.stdout"
 
-- name: Enable drupal module facets
-  command: drush en -y facets
-  args:
-    chdir: "{{ drupal_core_path }}"
-  register: install_facets
-  changed_when: "'enabled successfully' in install_facets.stdout"
-
 - name: Get solr config files to copy
   command: "find /var/www/html/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x -type f"
   register: files_to_copy
+  changed_when: false
 
 - name: Copy solr config files
   copy:


### PR DESCRIPTION
## What does this Pull Request do?
* Enables search_api_solr, search_api_solr_defaults, facets modules
* Sets the default_solr_server config
* Copies `/var/www/html/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x` into `/var/solr/data/CLAW/conf` 
* makes solr role as a dependency to webserver and restarts solr 

## How should this be tested?
* Get the PR
* vagrant up

## Additional Notes
* Need feedback to confirm/make the above tasks idempotent

## Interested parties
@jonathangreen 
@whikloj 