### PR TITLE
Copy JWT around

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -22,12 +22,14 @@ tomcat8_java_opts:
   - -Dcantaloupe.config={{ cantaloupe_symlink }}/cantaloupe.properties
   - -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
 
+fcrepo_syn_default_public_key_path: /var/lib/tomcat8/conf/public.key
+
 fcrepo_syn_sites:
   - algorithm: RS256
     encoding: PEM
     anonymous: true
     default: true
-    path: /home/ubuntu/auth/public.key
+    path: "{{ fcrepo_syn_default_public_key_path }}"
 
 fcrepo_syn_tokens:
   - user: admin

--- a/roles/internal/crayfish/defaults/main.yml
+++ b/roles/internal/crayfish/defaults/main.yml
@@ -6,6 +6,8 @@ crayfish_services:
   - Houdini
   - Milliner
   - Hypercube
+  
+crayfish_install_dir: /var/www/html/Crayfish
 
 crayfish_syn_token: islandora
 

--- a/roles/internal/crayfish/tasks/install.yml
+++ b/roles/internal/crayfish/tasks/install.yml
@@ -15,25 +15,31 @@
 - name: Install crayfish code
   git:
     repo: https://github.com/Islandora-CLAW/Crayfish.git
-    dest: "/var/www/html/Crayfish"
+    dest: "{{ crayfish_install_dir }}"
     version: "{{ crayfish_version_tag }}"
 
 - name: Build crayfish code including dependencies
   composer:
     command: install
-    working_dir: /var/www/html/Crayfish/{{item}}
+    working_dir: "{{ crayfish_install_dir }}/{{item}}"
   with_items: "{{ crayfish_services }}"
 
 - name: Configure crayfish code
   template:
     src: "{{item}}.config.yaml.j2"
-    dest: "/var/www/html/Crayfish/{{item}}/cfg/config.yaml"
+    dest: "{{ crayfish_install_dir }}/{{item}}/cfg/config.yaml"
   with_items: "{{ crayfish_services }}"
+
+- name: Get SSL keys
+  include_role: 
+    name: keymaster
+  vars:
+    ssl_key_public_output_path: "{{ crayfish_install_dir }}/public.key"
 
 - name: Install auth config
   template:
     src: "syn-settings.xml.jp2"
-    dest: "/var/www/html/Crayfish/{{item}}/syn-settings.xml"
+    dest: "{{ crayfish_install_dir }}/{{item}}/syn-settings.xml"
   with_items: "{{ crayfish_services }}"
 
 - name: Create Islandora log dir

--- a/roles/internal/crayfish/templates/syn-settings.xml.jp2
+++ b/roles/internal/crayfish/templates/syn-settings.xml.jp2
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- managed by Ansible -->
 <config version='1'>
-    <site algorithm='RS256' encoding='PEM' path='/home/ubuntu/auth/public.key' default='true' anonymous='true'/>
+    <site algorithm='RS256' encoding='PEM' path='{{ crayfish_install_dir }}/public.key' default='true' anonymous='true'/>
     <token user='admin' roles='admin'>
         {{ crayfish_syn_token }}
     </token>

--- a/roles/internal/fcrepo-syn/defaults/main.yml
+++ b/roles/internal/fcrepo-syn/defaults/main.yml
@@ -4,6 +4,7 @@ fcrepo_syn_version: 0.1.0
 fcrepo_syn_folder: /opt/syn
 fcrepo_syn_user: tomcat8
 fcrepo_syn_tomcat_home: /var/lib/tomcat8
+fcrepo_syn_default_public_key_path: /var/lib/tomcat8/conf/public.key
 fcrepo_syn_sites: []
 # - url:
 #   algorithm:

--- a/roles/internal/fcrepo-syn/tasks/config.yml
+++ b/roles/internal/fcrepo-syn/tasks/config.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Get SSL keys
+  include_role: 
+    name: keymaster
+  vars:
+    ssl_key_public_output_path: "{{ fcrepo_syn_default_public_key_path }}"
+
 - name: Copy templated syn-settings.xml
   template:
     src: syn-settings.xml

--- a/roles/internal/keymaster/defaults/main.yml
+++ b/roles/internal/keymaster/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+  
+ssl_key_directory: /opt/keys/claw
+ssl_key_public_file: public.key
+ssl_key_private_file: private.key
+ssl_key_private_output_path: /tmp/private.key
+ssl_key_public_output_path: /tmp/public.key

--- a/roles/internal/keymaster/tasks/main.yml
+++ b/roles/internal/keymaster/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Create JWT Key Path
+  file:
+    state: directory
+    path: "{{ ssl_key_directory }}"
+
+- name: Create JWT Private Key
+  command: openssl genrsa -out "{{ ssl_key_directory }}/{{ ssl_key_private_file }}" 2048
+  args:
+    creates: "{{ ssl_key_directory }}/{{ ssl_key_private_file }}"
+
+- name: Create JWT Public Key
+  command: openssl rsa -pubout -in "{{ ssl_key_directory }}/{{ ssl_key_private_file }}" -out "{{ ssl_key_directory }}/{{ ssl_key_public_file }}"
+  args:
+    creates: "{{ ssl_key_directory }}/{{ ssl_key_public_file }}"
+
+- name: Copy public key out
+  copy:
+    src: "{{ ssl_key_directory }}/{{ ssl_key_public_file }}"
+    dest: "{{ ssl_key_public_output_path }}"
+    mode: 0644
+    remote_src: yes
+    
+- name: Copy private key out
+  copy:
+    src: "{{ ssl_key_directory }}/{{ ssl_key_private_file }}"
+    dest: "{{ ssl_key_private_output_path }}"
+    mode: 0644
+    remote_src: true

--- a/roles/internal/webserver-app/tasks/jwt.yml
+++ b/roles/internal/webserver-app/tasks/jwt.yml
@@ -1,3 +1,5 @@
+---
+
 - name: Create JWT Key Path
   file:
     state: directory
@@ -5,15 +7,11 @@
     owner: "{{ webserver_app_user }}"
     group: "{{ webserver_app_user }}"
 
-- name: Create JWT Private Key
-  command: openssl genrsa -out "{{ webserver_app_jwt_key_path }}/private.key" 2048
-  args:
-    creates: "{{ webserver_app_jwt_key_path }}/private.key"
-
-- name: Create JWT Public Key
-  command: openssl rsa -pubout -in "{{ webserver_app_jwt_key_path }}/private.key" -out "{{ webserver_app_jwt_key_path }}/public.key"
-  args:
-    creates: "{{ webserver_app_jwt_key_path }}/public.key"
+- name: Get SSL keys
+  include_role: 
+    name: keymaster
+  vars:
+    ssl_key_private_output_path: "{{ webserver_app_jwt_key_path }}/private.key"
 
 - name: Create JWT Config Path
   file:


### PR DESCRIPTION
Partially resolves: Islandora-CLAW/CLAW#702

This PR adds a new role called **keymaster**. All it does is generate a key in a single location and allow for the copying of either or both of the private/public keys around.

This role is not referenced in the playbook except by other roles that require the keys.

To test, please pull this PR and build it.

Everything should work out of the box.

### Thoughts of things not yet done: 
1. I haven't added a way to copy the keys in from the host to the system.
1. If this is on a multiple server setup, perhaps the key generation should be on the host system and then could be copied to all the various remote targets.

<img src="https://33.media.tumblr.com/58bbbca30b70f2a4e53214e56d70a5a5/tumblr_mpwoezLoKj1rhxd21o3_r1_500.gif" alt="Vinz Clortho"/>