### PR TITLE
Switch to CENTOS with the ISLANDORA_VAGRANT_DISTRO environment var

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ export ISLANDORA_VAGRANT_CPUS=4
 export ISLANDORA_VAGRANT_MEMORY=4096
 ```
 
+### Using CENTOS
+
+Ubuntu 16.04 is the default linux distribution used by claw-playbook.  If you want to use CENTOS 7 instead, set the `ISLANDORA_VAGRANT_DISTRO` environment variable to `centos/7`.  The easiest way to do this is to export the environment variable into your shell before running Vagrant commands. Otherwise you will have to provide the variable for every Vagrant command you issue.
+
+```bash
+ISLANDORA_VAGRANT_DISTRO="centos/7" vagrant up
+ISLANDORA_VAGRANT_DISTRO="centos/7" vagrant ssh
+```
+
+If you are not using `vagrant up` to bring up a box, and are running `ansible-playbook` against it manually, you will need to set `ansible_ssh_user` to `vagrant` for your hosts.  It's easiest to add this value to `inventory/vagrant/group_vars/all.yml` to set the value for all hosts.  This is not neccessary if using Vagrant, as the ssh user is passed to ansible via the Vagrantfile.
+
 ## Use
 
 1. clone the repo

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This virtual machine **should not** be used in production **yet**.
 2. [Vagrant](http://www.vagrantup.com/) 1.8.5+
 3. [git](https://git-scm.com/)
 4. [ansible](https://www.ansible.com/community) 2.3+
+5. [virtualbox-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin (If targeting CENTOS)
 
 ## Variables
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,12 @@ $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "3072")
 $hostname = ENV.fetch("ISLANDORA_VAGRANT_HOSTNAME", "claw")
 $virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "IslandoraCLAW")
 
+# Available boxes are 'ubuntu/xenial64' and 'centos/7'
+$vagrantBox = ENV.fetch("ISLANDORA_VAGRANT_DISTRO", "ubuntu/xenial64")
+
+# On Ubuntu, user is ubuntu, on all others, user is vagrant
+$vagrantUser = if $vagrantBox == "ubuntu/xenial64" then "ubuntu" else "vagrant" end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.name = "Islandora CLAW"
@@ -17,10 +23,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = $hostname
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = $vagrantBox
 
-  # Setup the shared folder
-  home_dir = "/home/ubuntu"
+  # Configure home directory
+  home_dir = "/home/" + $vagrantUser
+
+  # Configure sync directory
   config.vm.synced_folder ".", home_dir + "/islandora"
 
   config.vm.network :forwarded_port, guest: 8000, host: 8000 # Apache
@@ -45,6 +53,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file} --roles-path=roles/external --force"
     ansible.limit = "all"
     ansible.inventory_path = "inventory/vagrant"
+    ansible.host_vars = {
+      "all" => { "ansible_ssh_user" => $vagrantUser }
+    }
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,8 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+Vagrant.require_version ">= 1.8.5", "<= 2.0.1"
+
 $cpus   = ENV.fetch("ISLANDORA_VAGRANT_CPUS", "1")
 $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "3072")
 $hostname = ENV.fetch("ISLANDORA_VAGRANT_HOSTNAME", "claw")


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/746

Reads in the ISLANDORA_VAGRANT_DISTRO environment variable to switch between Ubuntu and Cent.

### Testing

#### Ubuntu

Spin up an Ubuntu and ssh into it.  Both Vagrant and Ansible should be able to ssh in.  You can confirm with `vagrant ssh` for Vagrant and `ansible-playbook -i inventory/vagrant bootstrap.yml` for Ansible.
```bash
$ vagrant up --no-provision
...
$ vagrant ssh
...
$ exit
$ ansible-playbook -i inventory/vagrant bootstrap.yml
```

#### Cent
You can `vagrant up` a box and ssh into it, but bootstrap.yml will fail because it uses apt-get.  You should still try to run it to verify you aren't getting flagged as a man in the middle attack.

```bash
$ ISLANDORA_VAGRANT_DISTRO="centos/7" vagrant up --no-provision
...
$ ISLANDORA_VAGRANT_DISTRO="centos/7" vagrant ssh
...
$ exit
$ ansible-playbook -i inventory/vagrant bootstrap.yml
```

You should see the following failure for bootstrapping, and that's to be expected:
```
daniel@daniel-Latitude-3560:~/Code/Environments/claw-playbook$ ansible-playbook -i inventory/vagrant bootstrap.yml 

PLAY [bootstrap] ***************************************************************************************************************************************************************************************************

TASK [install python] **********************************************************************************************************************************************************************************************
Thursday 09 November 2017  11:27:57 -0400 (0:00:00.049)       0:00:00.049 ***** 
ok: [default]

TASK [install aptitude] ********************************************************************************************************************************************************************************************
Thursday 09 November 2017  11:27:57 -0400 (0:00:00.531)       0:00:00.580 ***** 
fatal: [default]: FAILED! => {"changed": false, "cmd": "apt-get update", "failed": true, "msg": "[Errno 2] No such file or directory", "rc": 2}
	to retry, use: --limit @/home/daniel/Code/Environments/claw-playbook/bootstrap.retry

PLAY RECAP *********************************************************************************************************************************************************************************************************
default                    : ok=1    changed=0    unreachable=0    failed=1   

Thursday 09 November 2017  11:27:58 -0400 (0:00:00.623)       0:00:01.204 ***** 
=============================================================================== 
install aptitude -------------------------------------------------------- 0.62s
install python ---------------------------------------------------------- 0.53s
```

If you see something like the following, your ansible_ssh_user variable is not correct.  That's not to be expected:
```
daniel@daniel-Latitude-3560:~/Code/Environments/claw-playbook$ ansible-playbook -i inventory/vagrant bootstrap.yml 

PLAY [bootstrap] ***************************************************************************************************************************************************************************************************

TASK [install python] **********************************************************************************************************************************************************************************************
Thursday 09 November 2017  11:25:22 -0400 (0:00:00.049)       0:00:00.049 ***** 
fatal: [default]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\n@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @\r\n@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\nIT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\r\nSomeone could be eavesdropping on you right now (man-in-the-middle attack)!\r\nIt is also possible that a host key has just been changed.\r\nThe fingerprint for the ECDSA key sent by the remote host is\nSHA256:7CrC5OSb6xSqp0KyvCCSQpbnFOsC0ibN79iN0ELkKeQ.\r\nPlease contact your system administrator.\r\nAdd correct host key in /home/daniel/.ssh/known_hosts to get rid of this message.\r\nOffending ECDSA key in /home/daniel/.ssh/known_hosts:9\r\n  remove with:\r\n  ssh-keygen -f \"/home/daniel/.ssh/known_hosts\" -R [127.0.0.1]:2222\r\nChallenge/response authentication is disabled to avoid man-in-the-middle attacks.\r\nPermission denied (publickey,gssapi-keyex,gssapi-with-mic).\r\n", "unreachable": true}
	to retry, use: --limit @/home/daniel/Code/Environments/claw-playbook/bootstrap.retry

PLAY RECAP *********************************************************************************************************************************************************************************************************
default                    : ok=0    changed=0    unreachable=1    failed=0   

Thursday 09 November 2017  11:25:23 -0400 (0:00:00.114)       0:00:00.163 ***** 
=============================================================================== 
install python ---------------------------------------------------------- 0.11s
```

This PR doesn't take CENTOS support any further, but should be considered a first step in that direction.