### PR TITLE
Handing Centos setup in bootstrap.yml

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -3,10 +3,8 @@
 - name: bootstrap
   hosts: all
   become: yes
-  gather_facts: false
+  gather_facts: true
 
-  # TODO: this probably needs to be made general for RHEL, it will only
-  # work for ubuntu right now.
   tasks:
     # python isn't installed by default on ubuntu 16.04 so we need
     # to do that with the raw command before
@@ -16,6 +14,7 @@
       changed_when:
         - output.stdout != ""
         - output.stdout != "\r\n"
+      when: ansible_os_family == "Debian"
 
     # also need to make sure aptitude is installed for the apt
     # commands in ansible.
@@ -24,10 +23,20 @@
         name: aptitude
         state: present
         update_cache: yes
+      when: ansible_os_family == "Debian"
 
     # install some packages we would like on every server
-    - name: install extra packages
-      apt:
+    - name: install extra packages ubuntu
+      package:
         name: "{{ item }}"
         state: present
-      with_items: "{{ islandora_extra_packages }}"
+      with_items: "{{ islandora_extra_ubuntu_packages }}"
+      when: ansible_os_family == "Debian"
+
+    # install some packages we would like on every server
+    - name: install extra packages centos
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ islandora_extra_centos_packages }}"
+      when: ansible_os_family == "RedHat"

--- a/inventory/vagrant/group_vars/all.yml
+++ b/inventory/vagrant/group_vars/all.yml
@@ -1,6 +1,6 @@
 ---
 
-islandora_extra_packages:
+islandora_extra_ubuntu_packages:
   - wget
   - curl
   - htop
@@ -10,5 +10,18 @@ islandora_extra_packages:
   - unzip
   - build-essential
   - vim
+
+islandora_extra_centos_packages:
+  - wget
+  - curl
+  - tree
+  - zsh
+  - unzip
+  - vim
+  - make
+  - automake
+  - gcc
+  - gcc-c++
+  - kernel-devel
 
 postgresql_user: postgres

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,8 @@
 ---
 
 - include: bootstrap.yml
+  tags:
+    - bootstrap
 - include: database.yml
 - include: webserver.yml
 - include: tomcat.yml


### PR DESCRIPTION
Resolves: https://github.com/Islandora-CLAW/CLAW/issues/749

Depends on https://github.com/Islandora-CLAW/CLAW/issues/746

This PR sets up bootstrapping for Centos systems.  It skips installing python and aptitude, and uses a different list of packages.  I'm replacing `build-essential` with equivalent packages available to yum, and am removing some that don't exist without adding extra repos.

You can test it with
```bash
ISLANDORA_VAGRANT_DISTRO="centos/7" vagrant up --no-provision
ansible-playbook -i inventory/vagrant -t bootstrap playbook.yml
```

It works, but I'm sure it can be done better and am open to suggestions.  