### PR TITLE
Fix FITS web service classloading

### DIFF
--- a/roles/internal/fits/tasks/config-ws.yml
+++ b/roles/internal/fits/tasks/config-ws.yml
@@ -2,7 +2,8 @@
 - name: Set fits.home in catalina.properties
   lineinfile:
     path: "{{ tomcat8_home }}/conf/catalina.properties"
-    line: 'fits.home="{{ fits_install_symlink }}"'
+    regexp: "^fits.home="
+    line: "fits.home={{ fits_install_symlink }}"
   notify: restart tomcat8
 
 - name: Set shared.loader in catalina.properties

--- a/roles/internal/fits/tasks/install.yml
+++ b/roles/internal/fits/tasks/install.yml
@@ -14,3 +14,5 @@
     state: link
     src: "{{ fits_install_root }}/fits-{{ fits_version }}"
     dest: "{{ fits_install_symlink }}"
+    owner: "{{ fits_user }}"
+    group: "{{ fits_group }}"


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Fixes the FITS web service that was not working correctly for me.

After bringing up the environment and accessing http://localhost:8080/fits/version (or using the `/examine` endpoint) this exception is displayed indicating a class loading problem:

```
HTTP Status 500 - Servlet execution threw an exception
[..]
javax.servlet.ServletException: Servlet execution threw an exception
	org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)

root cause
java.lang.NoClassDefFoundError: edu/harvard/hul/ois/fits/exceptions/FitsException
	edu.harvard.hul.ois.fits.service.pool.FitsWrapperFactory.create(FitsWrapperFactory.java:25)
	edu.harvard.hul.ois.fits.service.pool.FitsWrapperFactory.create(FitsWrapperFactory.java:18)
	org.apache.commons.pool2.BasePooledObjectFactory.makeObject(BasePooledObjectFactory.java:60)
	[..]
	org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)

root cause
java.lang.ClassNotFoundException: edu.harvard.hul.ois.fits.exceptions.FitsException
	org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1309)
	[..]
	org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
```

This PR removes the quotes around the configured fits home path in `catalina.properties`. In Java properties files, single-quotes or double-quotes are considered part of the string.

# What's new?

* Unquote `fits.home` value in `catalina.properties` 
* Make sure the fits symlink is also owned by the fits user

# How should this be tested?

* Reprovision FITS to an existing environments with:
  `ansible-playbook -i ./inventory/vagrant/hosts  playbook.yml --tags fits`
* Access the FITS web service and make sure it loads correctly:
  `curl -vv http://localhost:8080/fits/version`

# Interested parties
@Islandora-CLAW/committers