### PR TITLE
ActiveMQ service improvements

### DIFF
--- a/roles/internal/activemq/defaults/main.yml
+++ b/roles/internal/activemq/defaults/main.yml
@@ -2,6 +2,5 @@
 
 activemq_version: 5.14.5
 activemq_install_root: /opt
-activemq_user: ubuntu
-activemq_group: ubuntu
-
+activemq_user: activemq
+activemq_create_user: yes

--- a/roles/internal/activemq/meta/main.yml
+++ b/roles/internal/activemq/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
       versions:
         - trusty
         - utopic
+        - xenial
   galaxy_tags:
     - message:queues
     - messaging

--- a/roles/internal/activemq/tasks/install.yml
+++ b/roles/internal/activemq/tasks/install.yml
@@ -6,7 +6,6 @@
     src: http://archive.apache.org/dist/activemq/{{ activemq_version }}/apache-activemq-{{ activemq_version }}-bin.tar.gz
     dest: "{{ activemq_install_root }}"
     owner: "{{ activemq_user }}"
-    group: "{{ activemq_group }}"
     creates: "{{ activemq_install_root }}/activemq"
 
 - name: Move activemq
@@ -14,11 +13,10 @@
   args:
     creates: "{{ activemq_install_root }}/activemq"
 
-- name: Create symlink
-  file:
-    state: link
-    src: "/opt/activemq/bin/activemq"
-    dest: "/etc/init.d/activemq"
+- name: Create systemd unit
+  template:
+    src: activemq.service.j2
+    dest: /etc/systemd/system/activemq.service
 
 - name: Reload systemd
   systemd:

--- a/roles/internal/activemq/tasks/install.yml
+++ b/roles/internal/activemq/tasks/install.yml
@@ -13,6 +13,13 @@
   args:
     creates: "{{ activemq_install_root }}/activemq"
 
+# Transitional removal of old-style init.d symlink
+# This task can be removed in the future.
+- name: Remove init.d symlink
+  file:
+    path: /etc/init.d/activemq
+    state: absent
+
 - name: Create systemd unit
   template:
     src: activemq.service.j2

--- a/roles/internal/activemq/tasks/main.yml
+++ b/roles/internal/activemq/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- include: user.yml
+  tags:
+    - activemq
+    - activemq-user
+
 - include: install.yml
   tags:
     - activemq

--- a/roles/internal/activemq/tasks/user.yml
+++ b/roles/internal/activemq/tasks/user.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Create ActiveMQ system user
+  user:
+    name: "{{ activemq_user }}"
+    system: yes
+    state: present
+  when: activemq_create_user

--- a/roles/internal/activemq/templates/activemq.service.j2
+++ b/roles/internal/activemq/templates/activemq.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Apache ActiveMQ
+After=network-online.target
+
+[Service]
+Type=forking
+PIDFile={{activemq_install_root}}/activemq/data/activemq.pid
+WorkingDirectory={{activemq_install_root}}/activemq/bin
+ExecStart={{activemq_install_root}}/activemq/bin/activemq start
+ExecStop={{activemq_install_root}}/activemq/bin/activemq stop
+Restart=on-abort
+User={{activemq_user}}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Removes the need for an `ubuntu` user that is currently required to run ActiveMQ.

Similar background as raised for the old dev environment: Islandora-CLAW/claw_vagrant#57

This PR adds a dedicated activemq system user.

# What's new?

* Added the `activemq` system user.
* Added a systemd unit to manage the activemq service, which now runs as the activemq system user.
* Added a transitional task that removes the old init.d symlink

# How should this be tested?

* Reprovision ActiceMQ to an existing environments with:
  `ansible-playbook -i ./inventory/vagrant/hosts  playbook.yml --tags activemq`
* Cycle activemq: `sudo systemctl restart activemq`
* Access the ActiceMQ web UI and make sure it loads correctly: http://localhost:8161/admin/

# Interested parties

@Islandora-CLAW/committers