### PR TITLE
Define fedora.home environment variable

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -16,6 +16,7 @@ tomcat8_java_opts:
   - -XX:MaxNewSize=256m
   - -XX:PermSize=256m
   - -XX:MaxPermSize=256m
+  - -Dfcrepo.home={{ fcrepo_home_dir }}
   - -Dfcrepo.modeshape.configuration=file://{{ fcrepo_home_dir }}/configs/repository.json
   - -Dfcrepo.activemq.configuration=file://{{ fcrepo_config_dir }}/activemq.xml
   - -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile={{ blazegraph_home_dir }}/conf/RWStore.properties


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/757

For some reason with all the https://github.com/Islandora-CLAW/CLAW/issues/640 PRs merged Fedora started to have permissions trouble. The simplest answer seems to be to define where fedora should store its data (and the problematic velocity.log file).

While this is one not a required parameter for Fedora to run, it otherwise uses the current working directory which I think is `/var/lib/tomcat8`. So I am guessing there are some issues using that.

For more fedora information see the [Application Configuration](https://wiki.duraspace.org/display/FEDORA4x/Application+Configuration) documentation.