### PR TITLE
add drupal solr related tasks

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -42,6 +42,9 @@ drupal_enable_modules:
   - search_api
   - carapace
   - islandora_image
+  - search_api_solr
+  - search_api_solr_defaults
+  - facets
 drupal_trusted_hosts:
   - ^localhost$
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,8 +4,8 @@
   tags:
     - bootstrap
 - include: database.yml
+- include: solr.yml
 - include: webserver.yml
 - include: tomcat.yml
-- include: solr.yml
 - include: crayfish.yml
 - include: karaf.yml

--- a/roles/internal/webserver-app/defaults/main.yml
+++ b/roles/internal/webserver-app/defaults/main.yml
@@ -10,3 +10,7 @@ webserver_app_jwt_config_path: /home/ubuntu/configs/jwt
 webserver_app_drupal_config_path: /home/ubuntu/configs/drupal
 
 webserver_app_user: ubuntu
+solr_user: solr
+solr_instance_conf_path: /var/solr/data/CLAW/conf
+
+webserver_document_root: /var/www/html

--- a/roles/internal/webserver-app/meta/main.yml
+++ b/roles/internal/webserver-app/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- role: solr

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -92,3 +92,26 @@
         (drupal_filehash_settings.changed is defined and drupal_filehash_settings.changed) or
         (drupal_node_rest.changed is defined and drupal_node_rest.changed) or
         (drupal_media_rest.changed is defined and drupal_media_rest.changed)
+
+- name: Set default solr server to point to CLAW core
+  command: drush -y config-set search_api.server.default_solr_server backend_config.connector_config.core CLAW
+  args:
+    chdir: "{{ drupal_core_path }}"
+  register: set_search_api_config
+  changed_when: "'Do you want to update' in set_search_api_config.stdout"
+
+- name: Get solr config files to copy
+  command: "find {{ webserver_document_root }}/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x -type f"
+  register: files_to_copy
+  changed_when: false
+
+- name: Copy solr config files
+  copy:
+    src: "{{ item }}"
+    dest: "{{ solr_instance_conf_path }}"
+    owner: "{{ solr_user }}"
+    group: "{{ solr_user }}"
+    remote_src: True
+  with_items:
+   - "{{ files_to_copy.stdout_lines }}"
+  notify: restart solr


### PR DESCRIPTION
(Rebasing conflicts.  So, easier for me to create new PR with the changes from this one: https://github.com/Islandora-Devops/claw-playbook/pull/24.)

## What does this Pull Request do?
* Enables search_api_solr, search_api_solr_defaults, facets modules
* Sets the default_solr_server config
* Copies `/var/www/html/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x` into `/var/solr/data/CLAW/conf` 
* makes solr role as a dependency to webserver and restarts solr 

## How should this be tested?
* Get the PR
* vagrant up

## Additional Notes
* Need feedback to confirm/make the above tasks idempotent

## Interested parties
@whikloj 