### PR TITLE
Ensure islandora namespace is in blazegraph

### DIFF
--- a/roles/internal/alpaca/defaults/main.yml
+++ b/roles/internal/alpaca/defaults/main.yml
@@ -27,4 +27,4 @@ alpaca_settings:
     settings:
       error.maxRedeliveries: 10
       input.stream: activemq:queue:islandora-indexing-triplestore
-      triplestore.baseUrl: http://localhost:8080/bigdata/namespace/kb/sparql
+      triplestore.baseUrl: http://localhost:8080/bigdata/namespace/islandora/sparql

--- a/roles/internal/apix/defaults/main.yml
+++ b/roles/internal/apix/defaults/main.yml
@@ -16,4 +16,4 @@ apix_config:
     settings:
       input.stream: activemq:topic:fedora
       triplestore.reindex.stream: activemq:queue:triplestore.reindex
-      triplestore.baseUrl: http://localhost:8080/bigdata/namespace/kb/sparql
+      triplestore.baseUrl: http://localhost:8080/bigdata/namespace/islandora/sparql

--- a/roles/internal/blazegraph/tasks/namespace.yml
+++ b/roles/internal/blazegraph/tasks/namespace.yml
@@ -1,17 +1,31 @@
 ---
 
+- name: "Wait for Blazegraph to come up"
+  uri:
+    url: "http://localhost:8080/bigdata/#namespaces"
+    status_code: 200
+    timeout: 5
+  register: result
+  until: result.status == 200
+  retries: 60
+  delay: 5
+
 - name: Setup namespace in blazegraph
-  command:
-    curl -v -X POST -H 'Content-Type:text/plain' --data-binary @blazegraph.properties http://localhost:8080/bigdata/namespace
-  args:
-    chdir: "{{ blazegraph_home_dir }}/conf"
-    warn: no
+  uri:
+    url: http://localhost:8080/bigdata/namespace
+    method: POST
+    body: "{{ lookup('file', 'blazegraph.properties') }}"
+    status_code: 201
+    headers:
+      Content-Type: "text/plain"
   when: blazegraph_war_download.changed is defined and blazegraph_war_download.changed
 
 - name: Setup inference in blazegraph
-  command:
-    curl -v -X POST -H 'Content-Type:text/plain' --data-binary @inference.nt http://localhost:8080/bigdata/namespace/islandora/sparql
-  args:
-    chdir: "{{ blazegraph_home_dir }}/conf"
-    warn: no
+  uri:
+    url: http://localhost:8080/bigdata/namespace/islandora/sparql
+    method: POST
+    body: "{{ lookup('file', 'inference.nt') }}"
+    status_code: 200
+    headers:
+      Content-Type: "text/plain"
   when: blazegraph_war_download.changed is defined and blazegraph_war_download.changed

--- a/roles/internal/blazegraph/tasks/namespace.yml
+++ b/roles/internal/blazegraph/tasks/namespace.yml
@@ -1,5 +1,13 @@
 ---
 
+# Need to make sure Blazegraph is up and running before applying config changes
+- debug: msg="restart Tomcat"
+  notify: restart tomcat8
+  changed_when: true
+
+# By default, ansible will run handlers at the end, here we are forcing ansible to restart tomcat
+- meta: flush_handlers
+
 - name: "Wait for Blazegraph to come up"
   uri:
     url: "http://localhost:8080/bigdata/#namespaces"
@@ -7,7 +15,7 @@
     timeout: 5
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 100
   delay: 5
 
 - name: Setup namespace in blazegraph

--- a/roles/internal/blazegraph/tasks/namespace.yml
+++ b/roles/internal/blazegraph/tasks/namespace.yml
@@ -15,7 +15,7 @@
     timeout: 5
   register: result
   until: result.status == 200
-  retries: 100
+  retries: 60
   delay: 5
 
 - name: Setup namespace in blazegraph


### PR DESCRIPTION
## What does this Pull Request do?
In Ansible, handlers get fired last.  If there are tasks that need the handlers to be fired, then handlers must be flushed (`- meta: flush_handlers`).  Initially, the Islandora namepsace was not being applied to blazegraph, perhaps because the tasks get run before blazegraph comes up.  This PR ensures that blazegraph comes up before running those tasks.  

## How should this be tested?
* Get the PR
* Ensure that the islandora namespace is available in http://localhost:8080/bigdata/#namespaces

## Interested parties
@dannylamb 
@jonathangreen 
