### PR TITLE
Add mysql user if not root

### DIFF
--- a/inventory/vagrant/group_vars/all.yml
+++ b/inventory/vagrant/group_vars/all.yml
@@ -31,4 +31,4 @@ mysql_users:
     host: "%"
     password: "{{ drupal_db_password }}"
     priv: "{{ drupal_db_name }}.*:ALL"
-
+    when: drupal_db_user != 'root'

--- a/inventory/vagrant/group_vars/all.yml
+++ b/inventory/vagrant/group_vars/all.yml
@@ -25,3 +25,10 @@ islandora_extra_centos_packages:
   - kernel-devel
 
 postgresql_user: postgres
+
+mysql_users:
+  - name: "{{ drupal_db_user }}"
+    host: "%"
+    password: "{{ drupal_db_password }}"
+    priv: "{{ drupal_db_name }}.*:ALL"
+


### PR DESCRIPTION
## Github issue
* https://github.com/Islandora-CLAW/CLAW/issues/762

## Changes
If the user wants to use a drupal user other than root, that user needs to be created.  Otherwise, ansible will fail.  This PR creates the mysql user and gives permissions for the drupal database for that user.

## Testing
* vagrant up with a different drupal_db_user than root: https://github.com/Islandora-Devops/claw-playbook/blob/master/inventory/vagrant/group_vars/webserver/drupal.yml#L20

@dannylamb 
  
  