### PR TITLE
set default drupal mysql user as drupal8

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The default Drupal login details are:
 
 ### MySQL
   
-  * username: root
+  * username: drupal8
   * password: islandora
 
 ### Fedora4

--- a/inventory/vagrant/group_vars/all.yml
+++ b/inventory/vagrant/group_vars/all.yml
@@ -31,4 +31,3 @@ mysql_users:
     host: "%"
     password: "{{ drupal_db_password }}"
     priv: "{{ drupal_db_name }}.*:ALL"
-    when: drupal_db_user != 'root'

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -17,7 +17,7 @@ drupal_composer_dependencies:
 drupal_composer_project_package: "drupal-composer/drupal-project:8.x-dev"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
-drupal_db_user: root
+drupal_db_user: drupal8
 drupal_db_password: islandora
 drupal_db_name: drupal8
 drupal_db_backend: "{{ claw_db }}"


### PR DESCRIPTION
## What does this Pull Request do?
Several users have reported that they are running into issue related to this PR https://github.com/Islandora-Devops/claw-playbook/pull/45.  

Though I cannot fully reproduce with vagrant, I think it may be due to mysql trying to create root user.  I suppose the conditional statement does not get applied in the variable setting.

It is good practice to use non root user of the database.  Thus, changing the default drupal user from root to drupal8.  

## How should this be tested?
vagrant up

## Interested parties
@jonathangreen @dannylamb 

