### PR TITLE
ensure indexing targets islandora namespace

### DIFF
--- a/inventory/vagrant/group_vars/karaf.yml
+++ b/inventory/vagrant/group_vars/karaf.yml
@@ -8,7 +8,7 @@ alpaca_settings:
     settings:
       error.maxRedeliveries: 10
       input.stream: activemq:queue:islandora-indexing-triplestore
-      triplestore.baseUrl: http://localhost:8080/bigdata/namespace/kb/sparql
+      triplestore.baseUrl: http://localhost:8080/bigdata/namespace/islandora/sparql
   - pid: ca.islandora.alpaca.indexing.fcrepo
     settings:
       error.maxRedeliveries: 10


### PR DESCRIPTION
## Ticket
* https://github.com/Islandora-CLAW/CLAW/issues/774

## What does it do
Sets the 'triplestore.baseUrl' in group_vars to islandora namespace.  This global variable was mistakenly configured to point to the kb namespace.

## Testing
* vagrant up
* create a node in drupal, verify that its properties are indexed in the triplestore under the islandora namespace (i.e drupal urls as subject)
