### PR TITLE
Can't conditionally define a variable

### DIFF
--- a/inventory/vagrant/group_vars/all.yml
+++ b/inventory/vagrant/group_vars/all.yml
@@ -26,9 +26,13 @@ islandora_extra_centos_packages:
 
 postgresql_user: postgres
 
-mysql_users:
-  - name: "{{ drupal_db_user }}"
-    host: "%"
-    password: "{{ drupal_db_password }}"
-    priv: "{{ drupal_db_name }}.*:ALL"
-    when: drupal_db_user != 'root'
+# If you are using a non-root database user,
+# you probably want to comment the next line
+# and un-comment the block below.
+mysql_users: []
+
+# mysql_users:
+#  - name: "{{ drupal_db_user }}"
+#    host: "%"
+#    password: "{{ drupal_db_password }}"
+#    priv: "{{ drupal_db_name }}.*:ALL"


### PR DESCRIPTION
Resolves: https://github.com/Islandora-CLAW/CLAW/issues/778

This error only occurs if you try to run the playbook a second time.
So if you bring up a vagrant with claw-playbook and then run (this assumes Ubuntu)
```
ansible-playbook -i inventory/vagrant -u ubuntu -e islandora_distro="ubuntu/xenial" playbook.yml
```
you should see the error documented in the ticket above.

An alternative would be to include a variable file using the `when:` statement but I think it is probably better to get people used to checking the variable files when altering the configuration.

Pinging @Natkeeran as he has used non-root MySQL users.