### PR TITLE
Update to new drupal-openseadragon role version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -57,7 +57,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon
   name: Islandora-Devops.drupal-openseadragon
-  version: 0.0.1
+  version: 0.0.2
 
 - src: https://github.com/Islandora-Devops/ansible-role-fcrepo
   name: Islandora-Devops.fcrepo


### PR DESCRIPTION
Updates the main claw-playbook to pull the tag `0.0.2` from the drupal-openseadragon role. This corresponds to the commit https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon/commit/0f05f8164de18686f3256cdc31e401d17ed6d2d2