### PR TITLE
Update requirements and group_vars to use updated tomcat role

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -23,7 +23,7 @@ tomcat8_java_opts:
   - -Dcantaloupe.config={{ cantaloupe_symlink }}/cantaloupe.properties
   - -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
 
-fcrepo_syn_tomcat_home: /opt/tomcat
+fcrepo_syn_tomcat_home: "{{ tomcat8_home }}"
 fcrepo_syn_default_public_key_path: "{{ fcrepo_syn_tomcat_home }}/conf/public.key"
 
 fcrepo_syn_sites:

--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -23,7 +23,8 @@ tomcat8_java_opts:
   - -Dcantaloupe.config={{ cantaloupe_symlink }}/cantaloupe.properties
   - -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
 
-fcrepo_syn_default_public_key_path: /var/lib/tomcat8/conf/public.key
+fcrepo_syn_tomcat_home: /opt/tomcat
+fcrepo_syn_default_public_key_path: "{{ fcrepo_syn_tomcat_home }}/conf/public.key"
 
 fcrepo_syn_sites:
   - algorithm: RS256

--- a/requirements.yml
+++ b/requirements.yml
@@ -75,7 +75,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-tomcat8
   name: Islandora-Devops.tomcat8
-  version: 0.0.1
+  version: 0.0.2
 
 - src: https://github.com/Islandora-Devops/ansible-role-fits
   name: Islandora-Devops.fits

--- a/requirements.yml
+++ b/requirements.yml
@@ -51,7 +51,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-blazegraph
   name: Islandora-Devops.blazegraph
-  version: 0.0.1
+  version: 0.0.2
 
 - src: https://github.com/Islandora-Devops/ansible-role-cantaloupe
   name: Islandora-Devops.cantaloupe


### PR DESCRIPTION
Related to: https://github.com/Islandora-Devops/ansible-role-tomcat8/issues/2 and https://github.com/Islandora-Devops/ansible-role-tomcat8/pull/3

This updates the requirements to pull in the updated ansible-role-tomcat8 and defines some needed variables (as the defaults in ansible-role-fcrepo-syn are now incorrect).
 