### PR TITLE
Use our drupal-project to pin drupal version to 8.4

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -14,7 +14,7 @@ drupal_composer_dependencies:
   - "drupal/facets:1.x-dev"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/islandora_image:dev-8.x-1.x"
-drupal_composer_project_package: "drupal-composer/drupal-project:8.x-dev"
+drupal_composer_project_package: "islandora/drupal-project:8.4"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8


### PR DESCRIPTION
Resolves: Islandora-CLAW/CLAW/issues/789

Copies the [`drupal-composer/drupal-project`](https://github.com/drupal-composer/drupal-project) and sets a version constraint on `drupal/core`. [Diff here](https://github.com/drupal-composer/drupal-project/compare/8.x...Islandora-CLAW:8.x-1.x).

Then we add a tag. This tag can be resolved from packagist with `islandora/drupal-project:tagName`, so we can update the `8.x-1.x` branch and make tags for following Drupal versions.

We will have to watch to ensure we don't get too far out of step with the base repo, as we will  have to merge changes into this repository to maintain our old tags.