### PR TITLE
Update grok dependency

### DIFF
--- a/crayfish.yml
+++ b/crayfish.yml
@@ -2,8 +2,13 @@
 
 - hosts: crayfish
   become: yes
+  vars:
+    php_enablerepo: "remi-php70"
+    php_packages_state: "latest"
 
   roles:
+    - name: geerlingguy.repo-remi
+      when: ansible_os_family == "RedHat"
     - geerlingguy.apache
     - geerlingguy.php
     - geerlingguy.git

--- a/requirements.yml
+++ b/requirements.yml
@@ -83,7 +83,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-grok
   name: Islandora-Devops.grok
-  version: 0.0.1
+  version: 0.0.2
 
 - src: https://github.com/Islandora-Devops/ansible-role-karaf
   name: Islandora-Devops.karaf


### PR DESCRIPTION
Updates the Grok dependency to the new "works with Centos" version.

Please test with both Ubuntu and Centos. Though Centos will probably fail once you get past Grok 😄 