### PR TITLE
claw_db undefined error fixed

### DIFF
--- a/inventory/vagrant/group_vars/crayfish.yml
+++ b/inventory/vagrant/group_vars/crayfish.yml
@@ -1,6 +1,6 @@
 ---
 
-crayfish_db: "{{ claw_db }}"
+crayfish_db: "{{ crayfish_db_name }}"
 
 crayfish_milliner_drupal_base_url: http://localhost:8000
 crayfish_milliner_gemini_base_url: http://localhost:8000/gemini


### PR DESCRIPTION
fatal: [default]: FAILED! => {"msg": "The conditional check 'crayfish_db == 'mysql'' failed. The error was: error while evaluating conditional (crayfish_db == 'mysql'): 'claw_db' is undefined\n\nThe error appears to have been in '/home/andr/CLAW-latest/claw-playbook/roles/external/Islandora-Devops.crayfish/tasks/db-mysql.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Create Gemini DB (mysql)\n  ^ here\n"}

When changed with crayfish_db_name installed on CentOS. Please check it on Debian.