### PR TITLE
Change vagrant requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This virtual machine **should not** be used in production **yet**.
 ## Requirements
 
 1. [VirtualBox](https://www.virtualbox.org/)
-2. [Vagrant](http://www.vagrantup.com/) 1.8.5+
+2. [Vagrant](http://www.vagrantup.com/) 2.0.1 - 2.0.5 (may work with newer versions, but un-tested)
 3. [git](https://git-scm.com/)
 4. [ansible](https://www.ansible.com/community) 2.3+
 5. [virtualbox-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin (If targeting CENTOS)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-Vagrant.require_version ">= 1.8.5", "<= 2.0.3"
+Vagrant.require_version ">= 2.0.1", "<= 2.0.5"
 
 $cpus   = ENV.fetch("ISLANDORA_VAGRANT_CPUS", "1")
 $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "3072")


### PR DESCRIPTION
Related to https://github.com/Islandora-CLAW/CLAW/issues/837

Now that all the vagrant boxes have been migrated from HashiCorp to Atlas you need a 2.0.0+ version of Vagrant or it can't load the base boxes.

This updates the documentation to specify you must have at least 2.0.1 - 2.0.5.

There could be a discussion about whether we remove the upper limit.

I just added a message that it might work, but is untested. We could add instructions on how to change that restriction... 🤷‍♂️ 

@Islandora-Devops/committers and @seth-shaw-unlv 

@seth-shaw-unlv you are not a member of this (Islandora-Devops) organization so I couldn't add you to the committers group. Can you join and I can add you to the team, as I find listing all the committers annoying.