### PR TITLE
update role versions for centos and push php version to inventory

### DIFF
--- a/crayfish.yml
+++ b/crayfish.yml
@@ -4,9 +4,10 @@
   become: yes
 
   roles:
+    - name: geerlingguy.repo-remi
+      when: ansible_os_family == "RedHat"
     - geerlingguy.apache
     - geerlingguy.php
     - geerlingguy.git
     - geerlingguy.composer
     - Islandora-Devops.crayfish
-

--- a/inventory/vagrant/group_vars/all/main.yml
+++ b/inventory/vagrant/group_vars/all/main.yml
@@ -34,3 +34,7 @@ mysql_users:
     host: "%"
     password: "{{ drupal_db_password }}"
     priv: "{{ drupal_db_name }}.*:ALL"
+
+# Used by both the webserver and crayfish role for CentOS.
+php_enablerepo: "remi-php72"
+php_packages_state: "latest"

--- a/requirements.yml
+++ b/requirements.yml
@@ -59,7 +59,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-crayfish
   name: Islandora-Devops.crayfish
-  version: 0.0.2
+  version: 0.0.3
 
 - src: https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon
   name: Islandora-Devops.drupal-openseadragon
@@ -83,11 +83,11 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-grok
   name: Islandora-Devops.grok
-  version: 0.0.1
+  version: 0.0.2
 
 - src: https://github.com/Islandora-Devops/ansible-role-karaf
   name: Islandora-Devops.karaf
-  version: 0.0.1
+  version: 0.0.2
 
 - src: https://github.com/Islandora-Devops/ansible-role-keymaster
   name: Islandora-Devops.keymaster

--- a/webserver.yml
+++ b/webserver.yml
@@ -2,9 +2,6 @@
 
 - hosts: webserver
   become: yes
-  vars:
-    php_enablerepo: "remi-php70"
-    php_packages_state: "latest"
 
   roles:
     - name: geerlingguy.repo-remi


### PR DESCRIPTION
**GitHub Issue**: 

- Islandora-CLAW/CLAW/issues/809
- and other CentOS bits

# What does this Pull Request do?

This PR should put all the final pieces in place for CentOS7 support.

# What's new?

* Updates ansible role versions to include CentOS fixes
* Moves the remi PHP version repo to the inventory (and bumps it to 7.2)

# How should this be tested?

* Clone a fresh copy of the playbook
* apply the PR
* `set ISLANDORA_DISTRO=centos/7`
* vagrant up
* pray while it provisions
* poke it to make sure all the Islandora bits work

# Interested parties

@Islandora-Devops/committers, esp @DigitLib and @ajs6f 