### PR TITLE
Hotfix/islandora claw claw issues 842

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you're looking for a development environment, using our Vagrant deployment is
 
 If you want to provision an all-in-one remote Ubuntu environment, like a production server:
 
-1. SSH into your remote server and add an [user with password-less sudo privileges](https://www.digitalocean.com/community/tutorials/how-to-create-a-sudo-user-on-ubuntu-quickstart), and make sure you can log in as that user. Its easiest if you use SSH keys for login, so that you an log in to the server without a password. Another option if you are no comfortable with password-less sudo is to set the `ansible_become_pass` variable in your inventory as outlined [here](http://docs.ansible.com/ansible/latest/become.html).
+1. SSH into your remote server and add an [user with password-less sudo privileges](https://www.digitalocean.com/community/tutorials/how-to-create-a-sudo-user-on-ubuntu-quickstart), and make sure you can log in as that user. Its easiest if you use SSH keys for login, so that you an log in to the server without a password. Another option if you are not comfortable with password-less sudo is to set the `ansible_become_pass` variable in your inventory as outlined [here](http://docs.ansible.com/ansible/latest/become.html).
 1. Clone the repository onto your local machine.
 1. Create an inventory for your new environment ('production' in this example): `cp -r inventory/vagrant inventory/production`.
 1. Edit `inventory/production/hosts` to point to your new environment by changing 'default' line to:

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,37 +5,37 @@
   version: 1.2.0
 
 - src: geerlingguy.apache
-  version: 2.1.1
+  version: 3.0.0
 
 - src: geerlingguy.php
-  version: 3.5.0
+  version: 3.6.0
 
 - src: geerlingguy.composer
-  version: 1.6.1
+  version: 1.7.0
 
 - src: geerlingguy.git
-  version: 1.4.0
+  version: 2.0.2
 
 - src: geerlingguy.mysql
-  version: 2.8.0
+  version: 2.9.0
 
 - src: geerlingguy.postgresql
-  version: 1.3.1
+  version: 1.4.3
 
 - src: geerlingguy.solr
-  version: 3.6.3
+  version: 4.2.1
 
 - src: geerlingguy.java
-  version: 1.7.4
+  version: 1.8.1
 
 - src: geerlingguy.drupal
-  version: 2.4.0
+  version: 2.5.0
 
 - src: geerlingguy.drush
-  version: 2.0.1
+  version: 3.1.1
 
 - src: geerlingguy.drupal-console
-  version: 1.1.0
+  version: 1.1.1
 
 - src: https://github.com/Islandora-Devops/ansible-role-activemq
   name: Islandora-Devops.activemq


### PR DESCRIPTION
**GitHub Issue**: [Islandora-CLAW 842](https://github.com/Islandora-CLAW/CLAW/issues/842)

# What does this Pull Request do?

This PR updates the `geerling-guy` Ansible Galaxy repo’s to the latest versions as of June 21 2018.

# What's new?

* `geerlingguy/Apache` updated from `2.1.1` to `3.0.0`
* `geerlingguy/PHP` updated from `3.5.0` to `3.6.0`
* `geerlingguy/composer` updated from `1.6.1` to `1.7.0`
* `geerlingguy/git` updated from `1.4.0` to `2.0.2`
* `geerlingguy/mysql` updated from `2.8.0` to `2.9.0`
* `geerlingguy/PostgreSQL` updated from `1.3.1` to `1.4.3`
* `geerlingguy/solr` updated from `3.6.3` to `4.2.1`
* `geerlingguy/java` updated from `1.7.4` to `1.8.1`
* `geerlingguy/Drupal` updated from `2.4.0` to `2.5.0`
* `geerlingguy/drush` updated from `2.0.1` to `3.1.1`
* `geerlingguy/Drupal-console` updated from `1.1.0` to `1.1.1`
* Corrected a typographical error in `README.md` (Didn’t warrant a separate issue and PR)

# How should this be tested?

* This has been tested against a fresh install of Ubuntu 16.04 on Virtualbox (Self-built; using the ISO from a local mirror of Ubuntu’s website).
* Vagrant VM has not yet been tested, however as there are no playbook updates, and the `geerlingguy` repos still support 14.04, there are no issues anticipated.

# Additional Notes:
As of June 22, 2018, I have yet to sign the contributor agreement, due to being at Islandora Camp EU in Limerick.  I’ll sign and update the PR (via comment) when I’ve emailed it across to the Islandora Association.

# Interested parties
I discussed this PR with @jonathangreen at Islandora Camp EU, and briefly demo’d the Ansible Log of install to him.