### PR TITLE
Permit current Vagrant version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Introduction
 
-The is an Ansible playbook for Islandora CLAW. It also has a vagrant file to bring up a development
+This is an Ansible playbook for Islandora CLAW. It also has a vagrant file to bring up a development
 environment virtual machine for Islandora CLAW.
 
 This virtual machine **should not** be used in production **yet**.
@@ -11,7 +11,7 @@ This virtual machine **should not** be used in production **yet**.
 ## Requirements
 
 1. [VirtualBox](https://www.virtualbox.org/)
-2. [Vagrant](http://www.vagrantup.com/) 2.0.1 - 2.0.5 (may work with newer versions, but un-tested)
+2. [Vagrant](http://www.vagrantup.com/) (Known to work with 2.0.1 - 2.1.2)
 3. [git](https://git-scm.com/)
 4. [ansible](https://www.ansible.com/community) 2.3+
 5. [virtualbox-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin (If targeting CENTOS)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-Vagrant.require_version ">= 2.0.1", "<= 2.0.5"
+Vagrant.require_version ">= 2.0.1"
 
 $cpus   = ENV.fetch("ISLANDORA_VAGRANT_CPUS", "1")
 $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "4096")


### PR DESCRIPTION
The playbook currently is known to work on versions of vagrant up to 2.1.2 (the current). But it involves manually editing the Vagrantfile to spin it up unless you have an old version of Vagrant.

I've done this in a way that we don't specify a "max" allowed version, because I don't think it's necessary until something is known to break. This way people who are just starting with vagrant don't have to re-install an older version. 