### PR TITLE
Workaround for content_translation columns not getting added when imp…

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -38,7 +38,6 @@ drupal_enable_modules:
   - search_api_solr_defaults
   - facets
   - islandora_core_feature
-  - islandora_demo_feature
 drupal_trusted_hosts:
   - ^localhost$
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"

--- a/post-install.yml
+++ b/post-install.yml
@@ -4,6 +4,31 @@
   become: yes
 
   tasks:
+    # Some tomfoolery to get the demo module to install.
+    # Subject to https://www.drupal.org/node/2599228
+    # Should be fixed in Drupal 8.7
+    - name: Install demo module (fail ok)
+      command: "{{ drush_path }} -y en islandora_demo_feature"
+      args:
+        chdir: "{{ drupal_core_path }}"
+      ignore_errors: yes
+    - name: Update entities
+      command: "{{ drush_path }} -y entity:updates"
+      args:
+        chdir: "{{ drupal_core_path }}"
+    - name: Uninstall demo module
+      command: "{{ drush_path }} -y pmu islandora_demo_feature"
+      args:
+        chdir: "{{ drupal_core_path }}"
+    - name: Install demo module (should not fail)
+      command: "{{ drush_path }} -y en islandora_demo_feature"
+      args:
+        chdir: "{{ drupal_core_path }}"
+    - name: Import feature
+      command: "{{ drush_path }} -y fim --bundle=islandora islandora_demo_feature"
+      args:
+        chdir: "{{ drupal_core_path }}"
+
     - name: Run migrations
       command: "{{ drush_path }} -y -l localhost:{{ apache_listen_port }} mim --group=islandora"
       args:

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -85,7 +85,7 @@
   notify: restart solr
 
 - name: Import features
-  command: "{{ drush_path }} -y fim --bundle=islandora islandora_core_feature,islandora_demo_feature"
+  command: "{{ drush_path }} -y fim --bundle=islandora islandora_core_feature"
   args:
     chdir: "{{ drupal_core_path }}"
 


### PR DESCRIPTION
…orting config

Resolves Islandora-CLAW/CLAW#873

After pulling down this code and running `vagrant up` to get a fresh box, the install should yield a functional environment.  I tested by adding an image and verifying that derivatives were generated and that they could be pulled out of Fedora.

Note, I have to purposefully run a command that fails during the post-install commands.  You'll get a big wall of red text from the fail, but then should see `ignoring...` underneath it and the play continue on.  That's to be expected.  We can stop doing it that way once https://www.drupal.org/node/2599228 lands in Drupal 8.7. 