### PR TITLE
Flysystem Install

### DIFF
--- a/inventory/vagrant/group_vars/karaf.yml
+++ b/inventory/vagrant/group_vars/karaf.yml
@@ -1,19 +1,30 @@
 ---
 
 alpaca_settings:
+  - pid: ca.islandora.alpaca.http.client
+    settings:
+      token.value: islandora
   - pid: ca.islandora.alpaca.connector.broadcast
     settings:
       input.stream: activemq:queue:islandora-connector-broadcast
   - pid: ca.islandora.alpaca.indexing.triplestore
     settings:
       error.maxRedeliveries: 10
-      input.stream: activemq:queue:islandora-indexing-triplestore
+      index.stream: activemq:queue:islandora-indexing-triplestore-index
+      delete.stream: activemq:queue:islandora-indexing-triplestore-delete
       triplestore.baseUrl: http://localhost:8080/bigdata/namespace/islandora/sparql
   - pid: ca.islandora.alpaca.indexing.fcrepo
     settings:
-      error.maxRedeliveries: 10
-      content.stream: activemq:queue:islandora-indexing-fcrepo-content
-      file.stream: activemq:queue:islandora-indexing-fcrepo-file
+      error.maxRedeliveries: 5
+      node.stream: activemq:queue:islandora-indexing-fcrepo-content
+      node.delete.stream: activemq:queue:islandora-indexing-fcrepo-delete
       media.stream: activemq:queue:islandora-indexing-fcrepo-media
-      delete.stream: activemq:queue:islandora-indexing-fcrepo-delete
+      file.stream: activemq:queue:islandora-indexing-fcrepo-file
+      file.delete.stream: activemq:queue:islandora-indexing-fcrepo-file-delete
       milliner.baseUrl: http://localhost:8000/milliner/
+      gemini.baseUrl: http://localhost:8000/gemini/
+  - pid: ca.islandora.alpaca.connector.houdini
+    settings:
+      error.maxRedeliveries: 10
+      in.stream: activemq:queue:islandora-connector-houdini
+      houdini.convert.url: http://localhost:8000/houdini/convert

--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -55,3 +55,5 @@ cantaloupe_processor_jp2: OpenJpegProcessor
 cantaloupe_cache_source: FilesystemCache
 cantaloupe_cache_derivative: FilesystemCache
 cantaloupe_create_FilesystemCache_dir: yes
+cantaloupe_resolver_static: HttpResolver
+cantaloupe_HttpResolver_BasicLookupStrategy_url_prefix: http://localhost:8000/

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -13,6 +13,9 @@ drupal_composer_dependencies:
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
   - "islandora/islandora_image:dev-8.x-1.x"
+  - "drupal/flysystem:^1.0"
+  - "drupal/token:^1.3"
+  - "drupal/features:^3.7"
 drupal_composer_project_package: "islandora/drupal-project:8.5"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
@@ -38,6 +41,9 @@ drupal_enable_modules:
   - search_api_solr_defaults
   - facets
   - islandora_core_feature
+  - content_translation
+  - flysystem
+  - token
 drupal_trusted_hosts:
   - ^localhost$
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -13,10 +13,6 @@ drupal_composer_dependencies:
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
   - "islandora/islandora_image:dev-8.x-1.x"
-  - "drupal/flysystem:^1.0"
-  - "drupal/token:^1.3"
-  - "drupal/features:^3.7"
-  - "islandora/chullo:dev-master"
 drupal_composer_project_package: "islandora/drupal-project:8.5"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
@@ -42,9 +38,6 @@ drupal_enable_modules:
   - search_api_solr_defaults
   - facets
   - islandora_core_feature
-  - content_translation
-  - flysystem
-  - token
 drupal_trusted_hosts:
   - ^localhost$
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -38,7 +38,6 @@ drupal_enable_modules:
   - search_api_solr_defaults
   - facets
   - islandora_core_feature
-  - islandora_demo_feature
 drupal_trusted_hosts:
   - ^localhost$
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -16,6 +16,7 @@ drupal_composer_dependencies:
   - "drupal/flysystem:^1.0"
   - "drupal/token:^1.3"
   - "drupal/features:^3.7"
+  - "islandora/chullo:dev-master"
 drupal_composer_project_package: "islandora/drupal-project:8.5"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"

--- a/post-install.yml
+++ b/post-install.yml
@@ -4,6 +4,31 @@
   become: yes
 
   tasks:
+    # Some tomfoolery to get the demo module to install.
+    # Subject to https://www.drupal.org/node/2599228
+    # Should be fixed in Drupal 8.7
+    - name: Install demo module (fail ok)
+      command: "{{ drush_path }} -y en islandora_demo_feature"
+      args:
+        chdir: "{{ drupal_core_path }}"
+      ignore_errors: yes
+    - name: Update entities
+      command: "{{ drush_path }} -y entity:updates"
+      args:
+        chdir: "{{ drupal_core_path }}"
+    - name: Uninstall demo module
+      command: "{{ drush_path }} -y pmu islandora_demo_feature"
+      args:
+        chdir: "{{ drupal_core_path }}"
+    - name: Install demo module (should not fail)
+      command: "{{ drush_path }} -y en islandora_demo_feature"
+      args:
+        chdir: "{{ drupal_core_path }}"
+    - name: Import feature
+      command: "{{ drush_path }} -y fim --bundle=islandora islandora_demo_feature"
+      args:
+        chdir: "{{ drupal_core_path }}"
+
     - name: Run migrations
       command: "{{ drush_path }} -y -l localhost:{{ apache_listen_port }} mim --group=islandora"
       args:

--- a/requirements.yml
+++ b/requirements.yml
@@ -59,7 +59,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-crayfish
   name: Islandora-Devops.crayfish
-  version: 0.0.3
+  version: 0.0.4
 
 - src: https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon
   name: Islandora-Devops.drupal-openseadragon

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -9,6 +9,14 @@
         '{{ host }}',
       {% endfor %}
       );
+      $settings['flysystem'] = [
+        'fedora' => [
+          'driver' => 'fedora',
+          'config' => [
+            'root' => 'http://localhost:8080/fcrepo/rest/',
+          ],
+        ],
+      ];
     path: "{{ drupal_trusted_hosts_file }}"
     marker: // {mark} ANSIBLE MANAGED BLOCK
 

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -85,7 +85,7 @@
   notify: restart solr
 
 - name: Import features
-  command: "{{ drush_path }} -y fim --bundle=islandora islandora_core_feature,islandora_demo_feature"
+  command: "{{ drush_path }} -y fim --bundle=islandora islandora_core_feature"
   args:
     chdir: "{{ drupal_core_path }}"
 


### PR DESCRIPTION
Install code for https://github.com/Islandora-CLAW/CLAW/issues/769

### Using this PR to install with Flysystem support

- Pull this code into claw-playbook
- `vagrant up`
  - It'll throw a wall of red text on you at the end, but that's because of the fix for https://github.com/Islandora-CLAW/CLAW/issues/873
- `vagrant ssh`
- `curl https://gist.githubusercontent.com/dannylamb/27ad287ae92afd7139a98435446550d6/raw/6e9f369139528d3445e19e187e6a22a5a1386d4d/gistfile1.txt | sudo bash`
    - It'll throw another message at you about some core config still referencing the `article` bundle, but that's ok.  It's benign, but I have to sort that out in `islandora_core_feature`.

### Testing Flysystem Support

I've been testing by adding an Image with a Preservation Master and watching it go.  It's easiest to see what's going on by checking Gemini.  Before doing anything, I confirm that the taxonomy terms are in and mapped.

```bash
vagrant@claw:~$ mysql -u root -pislandora gemini
mysql: [Warning] Using a password on the command line interface can be insecure.
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 119
Server version: 5.7.22-0ubuntu0.16.04.1 (Ubuntu)

Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> select fedora_uri, drupal_uri from Gemini;
+------------------------------------------------------------------------------------+------------------------------------------------------+
| fedora_uri                                                                         | drupal_uri                                           |
+------------------------------------------------------------------------------------+------------------------------------------------------+
| http://localhost:8080/fcrepo/rest/03/ad/74/0c/03ad740c-12b5-4b6b-950d-f26068dc16fe | http://localhost:8000/taxonomy/term/3?_format=jsonld |
| http://localhost:8080/fcrepo/rest/05/b3/33/25/05b33325-c6c3-4173-8ca7-ab892e173af7 | http://localhost:8000/taxonomy/term/9?_format=jsonld |
| http://localhost:8080/fcrepo/rest/06/96/8c/b0/06968cb0-318d-4ac9-a544-7e088cf29589 | http://localhost:8000/taxonomy/term/5?_format=jsonld |
| http://localhost:8080/fcrepo/rest/08/f4/c4/7d/08f4c47d-b1ec-4fb9-983c-9bbc39675b18 | http://localhost:8000/taxonomy/term/4?_format=jsonld |
| http://localhost:8080/fcrepo/rest/13/5c/04/b1/135c04b1-d6c7-490f-b4f1-280dc0aa06c0 | http://localhost:8000/taxonomy/term/1?_format=jsonld |
| http://localhost:8080/fcrepo/rest/2d/4f/70/f9/2d4f70f9-3c92-483e-a5df-fb4990e6d039 | http://localhost:8000/taxonomy/term/7?_format=jsonld |
| http://localhost:8080/fcrepo/rest/49/82/d2/75/4982d275-f612-4886-a527-b7d03986b391 | http://localhost:8000/taxonomy/term/8?_format=jsonld |
| http://localhost:8080/fcrepo/rest/cc/53/e4/01/cc53e401-350f-4ce4-9882-f21d243a8c35 | http://localhost:8000/taxonomy/term/6?_format=jsonld |
| http://localhost:8080/fcrepo/rest/fe/47/a0/bc/fe47a0bc-29b3-4d6b-9bf5-7cb7d3b89604 | http://localhost:8000/taxonomy/term/2?_format=jsonld |
+------------------------------------------------------------------------------------+------------------------------------------------------+
9 rows in set (0.00 sec)
```

Then go add an Image node and give it a Preservation Master media.

- From the landing page, click "+ Add Content"
- Select "Repository Item"
- Fill out the form and give it a tag of Image
- After submitting the form, view the Image object and click on its "Media" tab
- Click "+ Add Media"
- Click "Image"
- Fill out the form, upload a file, and give it a tag of "Preservation Master"
- Hover over the image in the Media's display, and you can see the link to the file is `http://localhost:8000/_flysystem/fedora/2018-07/...`

The file you uploaded will wind up in Fedora, but the derivatives will land in Drupal's public filesystem.  Check out Gemini again and it will have all the relevant nodes/media/files mapped.

```
mysql> select fedora_uri, drupal_uri from Gemini;
+--------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
| fedora_uri                                                                                             | drupal_uri                                                                                                   |
+--------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
| http://localhost:8080/fcrepo/rest/03/ad/74/0c/03ad740c-12b5-4b6b-950d-f26068dc16fe                     | http://localhost:8000/taxonomy/term/3?_format=jsonld                                                         |
| http://localhost:8080/fcrepo/rest/05/b3/33/25/05b33325-c6c3-4173-8ca7-ab892e173af7                     | http://localhost:8000/taxonomy/term/9?_format=jsonld                                                         |
| http://localhost:8080/fcrepo/rest/06/96/8c/b0/06968cb0-318d-4ac9-a544-7e088cf29589                     | http://localhost:8000/taxonomy/term/5?_format=jsonld                                                         |
| http://localhost:8080/fcrepo/rest/08/f4/c4/7d/08f4c47d-b1ec-4fb9-983c-9bbc39675b18                     | http://localhost:8000/taxonomy/term/4?_format=jsonld                                                         |
| http://localhost:8080/fcrepo/rest/0d/66/06/83/0d660683-551c-4037-b49b-38634f4e97f0                     | http://localhost:8000/media/3?_format=jsonld                                                                 |
| http://localhost:8080/fcrepo/rest/13/5c/04/b1/135c04b1-d6c7-490f-b4f1-280dc0aa06c0                     | http://localhost:8000/taxonomy/term/1?_format=jsonld                                                         |
| http://localhost:8080/fcrepo/rest/2d/4f/70/f9/2d4f70f9-3c92-483e-a5df-fb4990e6d039                     | http://localhost:8000/taxonomy/term/7?_format=jsonld                                                         |
| http://localhost:8080/fcrepo/rest/49/82/d2/75/4982d275-f612-4886-a527-b7d03986b391                     | http://localhost:8000/taxonomy/term/8?_format=jsonld                                                         |
| http://localhost:8080/fcrepo/rest/59/0c/10/d5/590c10d5-fb76-4789-86d0-3e3776a2aaf0                     | http://localhost:8000/node/1?_format=jsonld                                                                  |
| http://localhost:8080/fcrepo/rest/80/0a/e1/1c/800ae11c-06ce-413d-87a9-4fe38c046abc                     | http://localhost:8000/media/2?_format=jsonld                                                                 |
| http://localhost:8080/fcrepo/rest/2018-07/Hyboid-presents-Sternrekorder-Mix-for-Valerie-Collective.jpg | http://localhost:8000/_flysystem/fedora/2018-07/Hyboid-presents-Sternrekorder-Mix-for-Valerie-Collective.jpg |
| http://localhost:8080/fcrepo/rest/cc/53/e4/01/cc53e401-350f-4ce4-9882-f21d243a8c35                     | http://localhost:8000/taxonomy/term/6?_format=jsonld                                                         |
| http://localhost:8080/fcrepo/rest/fe/47/a0/bc/fe47a0bc-29b3-4d6b-9bf5-7cb7d3b89604                     | http://localhost:8000/taxonomy/term/2?_format=jsonld                                                         |
+--------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
13 rows in set (0.01 sec)

```

Note that files in Fedora are mapped in Gemini, whilst the others are not.  Conversely, for Media, if the source is _not_ in Fedora it is mapped in Gemini.  Media whose source are in Fedora are not mapped, but looked up using the `describedby` link header in Fedora responses.

You should be able to confirm that all the resources that should be are present in Fedora.