### PR TITLE
added controlled_access_terms and islandora_demo modules to the playbook

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -13,6 +13,8 @@ drupal_composer_dependencies:
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
   - "islandora/islandora_image:dev-8.x-1.x"
+  - "islandora/islandora_demo:dev-8.x-1.x"
+  - "islandora/controlled_access_terms:dev-8.x-1.x"
 drupal_composer_project_package: "islandora/drupal-project:8.5"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
@@ -38,6 +40,7 @@ drupal_enable_modules:
   - search_api_solr_defaults
   - facets
   - islandora_core_feature
+  - controlled_access_terms
 drupal_trusted_hosts:
   - ^localhost$
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"

--- a/post-install.yml
+++ b/post-install.yml
@@ -8,7 +8,7 @@
     # Subject to https://www.drupal.org/node/2599228
     # Should be fixed in Drupal 8.7
     - name: Install demo module (fail ok)
-      command: "{{ drush_path }} -y en islandora_demo_feature"
+      command: "{{ drush_path }} -y en islandora_demo"
       args:
         chdir: "{{ drupal_core_path }}"
       ignore_errors: yes
@@ -17,15 +17,15 @@
       args:
         chdir: "{{ drupal_core_path }}"
     - name: Uninstall demo module
-      command: "{{ drush_path }} -y pmu islandora_demo_feature"
+      command: "{{ drush_path }} -y pmu islandora_demo"
       args:
         chdir: "{{ drupal_core_path }}"
     - name: Install demo module (should not fail)
-      command: "{{ drush_path }} -y en islandora_demo_feature"
+      command: "{{ drush_path }} -y en islandora_demo"
       args:
         chdir: "{{ drupal_core_path }}"
     - name: Import feature
-      command: "{{ drush_path }} -y fim --bundle=islandora islandora_demo_feature"
+      command: "{{ drush_path }} -y fim --bundle=islandora islandora_demo"
       args:
         chdir: "{{ drupal_core_path }}"
 


### PR DESCRIPTION
Added the controlled_access_terms  and islandora_demo modules to the playbook.  Before merging this we may want to remove the islandora_demo_feature submodule from islandora.  

Some notes: After testing with the updated playbook adding taxonomy terms to repository_items media didn't seem to work.  I'm not sure if this is caused by changes in this pull request or changes to other modules that have been updated recently? 