### PR TITLE
Install Matomo server and module

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -42,6 +42,7 @@ drupal_enable_modules:
   - search_api_solr_defaults
   - facets
   - content_browser
+  - matomo
   - islandora_core_feature
   - controlled_access_terms
 drupal_trusted_hosts:

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -11,6 +11,7 @@ drupal_composer_dependencies:
   - "drupal/search_api_solr:^2.0"
   - "drupal/facets:1.x-dev"
   - "drupal/content_browser:^1.0@alpha"
+  - "drupal/matomo:^1.7"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
   - "islandora/islandora_image:dev-8.x-1.x"

--- a/requirements.yml
+++ b/requirements.yml
@@ -95,4 +95,4 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-matomo
   name: Islandora-Devops.matomo
-  Version: 0.0.1
+  version: 0.0.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -92,3 +92,6 @@
 - src: https://github.com/Islandora-Devops/ansible-role-keymaster
   name: Islandora-Devops.keymaster
   version: 0.0.1
+
+- src: https://github.com/Natkeeran/ansible-role-matomo
+  name: Islandora-Devops.matomo

--- a/requirements.yml
+++ b/requirements.yml
@@ -93,5 +93,6 @@
   name: Islandora-Devops.keymaster
   version: 0.0.1
 
-- src: https://github.com/Natkeeran/ansible-role-matomo
+- src: https://github.com/Islandora-Devops/ansible-role-matomo
   name: Islandora-Devops.matomo
+  Version: 0.0.1

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -117,4 +117,17 @@
   args:
     creates: "{{ drupal_external_libraries_directory }}/masonry"
 
+# Set Matomo Settings
+- name: Set Matomo site id.
+  command: "{{ drush_path }} -y config-set matomo.settings site_id 1"
+  args:
+    chdir: "{{ drupal_core_path }}"
+  register: set_search_api_config
+  changed_when: "'Do you want to update site_id' in set_search_api_config.stdout"
 
+- name: Set Matmo sever url.
+  command: "{{ drush_path }} -y config-set matomo.settings url_http http://localhost:8000/matomo/"
+  args:
+    chdir: "{{ drupal_core_path }}"
+  register: set_search_api_config
+  changed_when: "'Do you want to update site_id' in set_search_api_config.stdout"

--- a/webserver.yml
+++ b/webserver.yml
@@ -16,3 +16,4 @@
     - geerlingguy.drupal
     - Islandora-Devops.drupal-openseadragon
     - webserver-app
+    - Islandora-Devops.matomo


### PR DESCRIPTION
This PR installs matomo module in Islandora CLAW vagrant.  It addresses this ticket: https://github.com/Islandora-CLAW/CLAW/issues/792

## How to test
* Get the PR
* vagrant up
* Go to http://localhost:8000/admin/config/system/matomo, verify that default configuration is set.
* Go to http://localhost:8000/matomo/, Login (admin, islandora)
* Create pages, wait for a while, verify that those pages are recorded by matomo

## Notes
* Currently, it is only able to install in Ubuntu.  [Ansible script](https://github.com/Islandora-Devops/ansible-role-matomo) needs to configure it be installed in RedHat.  


@Islandora-Devops/committers 
