### PR TITLE
Installation for testing Islandora-CLAW/CLAW#888

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -14,9 +14,7 @@ drupal_composer_dependencies:
   - "drupal/matomo:^1.7"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
-  - "islandora/islandora_image:dev-8.x-1.x"
-  - "islandora/islandora_demo:dev-8.x-1.x"
-  - "islandora/controlled_access_terms:dev-8.x-1.x"
+  - "islandora/islandora_demo:dev-issue-888"
 drupal_composer_project_package: "islandora/drupal-project:8.6"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
@@ -44,7 +42,7 @@ drupal_enable_modules:
   - content_browser
   - matomo
   - islandora_core_feature
-  - controlled_access_terms
+  - controlled_access_terms_default_configuration
 drupal_trusted_hosts:
   - ^localhost$
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -14,7 +14,7 @@ drupal_composer_dependencies:
   - "drupal/matomo:^1.7"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
-  - "islandora/islandora_demo:dev-issue-888"
+  - "islandora/islandora_demo:dev-8.x-1.x"
 drupal_composer_project_package: "islandora/drupal-project:8.6"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -93,7 +93,7 @@
   notify: restart solr
 
 - name: Import features
-  command: "{{ drush_path }} -y fim --bundle=islandora islandora_core_feature"
+  command: "{{ drush_path }} -y fim islandora_core_feature,controlled_access_terms_default_configuration"
   args:
     chdir: "{{ drupal_core_path }}"
 


### PR DESCRIPTION
Use this to test all the PRs for Islandora-CLAW/CLAW#888

Resolves https://github.com/Islandora-CLAW/CLAW/issues/921

After you vagrant up, you should see several important changes.
- The `resource_types` vocabulary is filled with DCMI Type entries
![screenshot from 2018-10-03 10-54-54](https://user-images.githubusercontent.com/20773151/46415605-01db2f00-c6fc-11e8-8e91-ff3413b0fdd0.png)
- The form is divided into fieldsets using the `field_group` module
![screenshot from 2018-10-03 10-55-23](https://user-images.githubusercontent.com/20773151/46415619-09023d00-c6fc-11e8-8f9c-569e28808bc3.png)
- You can use `content_browser` for `field_member_of` and `field_media_of` to choose from existing nodes
![screenshot from 2018-10-03 10-58-22](https://user-images.githubusercontent.com/20773151/46415635-0ef81e00-c6fc-11e8-96f5-78d702bb9855.png)
- You can also use inline entity form to create new nodes and subjects from within the parent form
![screenshot from 2018-10-03 10-59-06](https://user-images.githubusercontent.com/20773151/46415644-14556880-c6fc-11e8-945b-9e53d516796f.png)
- The `model` field has a drop-down instead of an autocomplete
![screenshot from 2018-10-03 11-00-06](https://user-images.githubusercontent.com/20773151/46415658-19b2b300-c6fc-11e8-9a74-c8866bfa7ff7.png)
- There's `access control` and `display hints` fields, as well.
- Access control uses `field_permission` so that it's private to admins and the person who created the content
![screenshot from 2018-10-03 11-01-50](https://user-images.githubusercontent.com/20773151/46415728-44047080-c6fc-11e8-8490-9c9678c758ca.png)

Starting to look more full featured for sure!