### PR TITLE
Matomo version bump

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -95,4 +95,4 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-matomo
   name: Islandora-Devops.matomo
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Part of https://github.com/Islandora-CLAW/CLAW/issues/946

Bumps up the matomo role version so CENTOS builds will succeed.