### PR TITLE
Work on #997 - Optimizing composer memory requirements

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -4,6 +4,7 @@ drupal_build_composer_project: true
 drupal_composer_install_dir: /var/www/html/drupal
 drupal_core_owner: "{{ ansible_user }}"
 drupal_composer_dependencies:
+  - "zaporylie/composer-drupal-optimizations:^1.0"
   - "drupal/console:~1.0"
   - "drupal/devel:^1.0@beta"
   - "drupal/rdfui:1.x-dev"


### PR DESCRIPTION
Github issue: https://github.com/Islandora-CLAW/CLAW/issues/997

# What this PR does

Adds `zaporylie/composer-drupal-optimizations:^1.0` to Drupal's composer.json file, as advised in https://www.jeffgeerling.com/blog/2018/make-composer-operations-drupal-way-faster-and-easier-on-ram.

# How to test

1. check out this branch
1. build a clean Vagrant
1. ssh into the Vagrant and open `/var/www/html/drupal/composer.json`. "zaporylie/composer-drupal-optimizations": "^1.0" should be in the `require` section.
1. install a Drupal module that would normally cause composer to fail due to insufficient memory, e.g.:
   * `composer require drupal/jsonapi`
   * `composer require islandora/migrate_7x_claw`
   * try a module that has failed for you in the past
1. composer should successfully run, without reporting OOM errors. 

Thanks to @seth-shaw-unlv for the tip on how to add this to the Vagrant.

