### PR TITLE
Refactor blueprint

### DIFF
--- a/inventory/vagrant/group_vars/karaf.yml
+++ b/inventory/vagrant/group_vars/karaf.yml
@@ -1,30 +1,6 @@
 ---
 
-alpaca_settings:
-  - pid: ca.islandora.alpaca.http.client
-    settings:
-      token.value: islandora
-  - pid: ca.islandora.alpaca.connector.broadcast
-    settings:
-      input.stream: activemq:queue:islandora-connector-broadcast
-  - pid: ca.islandora.alpaca.indexing.triplestore
-    settings:
-      error.maxRedeliveries: 10
-      index.stream: activemq:queue:islandora-indexing-triplestore-index
-      delete.stream: activemq:queue:islandora-indexing-triplestore-delete
-      triplestore.baseUrl: http://localhost:8080/bigdata/namespace/islandora/sparql
-  - pid: ca.islandora.alpaca.indexing.fcrepo
-    settings:
-      error.maxRedeliveries: 5
-      node.stream: activemq:queue:islandora-indexing-fcrepo-content
-      node.delete.stream: activemq:queue:islandora-indexing-fcrepo-delete
-      media.stream: activemq:queue:islandora-indexing-fcrepo-media
-      file.stream: activemq:queue:islandora-indexing-fcrepo-file
-      file.delete.stream: activemq:queue:islandora-indexing-fcrepo-file-delete
-      milliner.baseUrl: http://localhost:8000/milliner/
-      gemini.baseUrl: http://localhost:8000/gemini/
-  - pid: ca.islandora.alpaca.connector.houdini
-    settings:
-      error.maxRedeliveries: 10
-      in.stream: activemq:queue:islandora-connector-houdini
-      houdini.convert.url: http://localhost:8000/houdini/convert
+# Comment in to build Alpaca from source
+alpaca_from_source: yes
+alpaca_version: refactor-blueprint
+alpaca_clone_directory: /opt/alpaca

--- a/inventory/vagrant/group_vars/karaf.yml
+++ b/inventory/vagrant/group_vars/karaf.yml
@@ -1,6 +1,6 @@
 ---
 
 # Comment in to build Alpaca from source
-alpaca_from_source: yes
-alpaca_version: refactor-blueprint
-alpaca_clone_directory: /opt/alpaca
+# alpaca_from_source: yes
+# alpaca_version: your-branch-name
+# alpaca_clone_directory: /opt/alpaca

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -15,7 +15,7 @@ drupal_composer_dependencies:
   - "drupal/matomo:^1.7"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
-  - "islandora/islandora_demo:dev-8.x-1.x"
+  - "islandora/islandora_demo:dev-refactor-blueprint"
 drupal_composer_project_package: "islandora/drupal-project:8.6"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -15,7 +15,7 @@ drupal_composer_dependencies:
   - "drupal/matomo:^1.7"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
-  - "islandora/islandora_demo:dev-refactor-blueprint"
+  - "islandora/islandora_demo:dev-8.x-1.x"
 drupal_composer_project_package: "islandora/drupal-project:8.6"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -4,6 +4,7 @@ drupal_build_composer_project: true
 drupal_composer_install_dir: /var/www/html/drupal
 drupal_core_owner: "{{ ansible_user }}"
 drupal_composer_dependencies:
+  - "zaporylie/composer-drupal-optimizations:^1.0"
   - "drupal/console:~1.0"
   - "drupal/devel:^1.0@beta"
   - "drupal/rdfui:1.x-dev"

--- a/requirements.yml
+++ b/requirements.yml
@@ -41,9 +41,9 @@
   name: Islandora-Devops.activemq
   version: 0.0.1
 
-- src: https://github.com/Islandora-Devops/ansible-role-alpaca
+- src: https://github.com/dannylamb/ansible-role-alpaca
   name: Islandora-Devops.alpaca
-  version: 0.0.2
+  version: refactor-blueprint
 
 - src: https://github.com/Islandora-Devops/ansible-role-apix
   name: Islandora-Devops.apix

--- a/requirements.yml
+++ b/requirements.yml
@@ -41,9 +41,9 @@
   name: Islandora-Devops.activemq
   version: 0.0.1
 
-- src: https://github.com/dannylamb/ansible-role-alpaca
+- src: https://github.com/Islandora-Devops/ansible-role-alpaca
   name: Islandora-Devops.alpaca
-  version: refactor-blueprint
+  version: 0.0.3
 
 - src: https://github.com/Islandora-Devops/ansible-role-apix
   name: Islandora-Devops.apix


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/957
Resolves https://github.com/Islandora-CLAW/CLAW/issues/974
Resolves https://github.com/Islandora-CLAW/CLAW/issues/982

Use this PR to test those issues.  This points the installer to my various `refactor-blueprint` branches across the stack to enable video derivatives.

## Testing Instructions

- Pull in this PR
- Delete your roles/external directory
- `vagrant up`

Once it's up, make a `Repository Item` and give it a Video media tagged as Original File.  Wait a bit and eventually you'll get service file derivative created :rocket: 

I've noticed that about half the time, there's issues with `fcrepo-indexing-triplestore` and `fcrepo-api-x` from deployment that will clog up the queue for a bit.  I think the issue has been there since we switched to Fedora 5, but I can't be sure.  It's intermittent, so if it's slow for you that's probably what's happening.  But be patient, it should sort itself out eventually and give you a derivative.
