### PR TITLE
install and enable pdf module and lib

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -13,6 +13,7 @@ drupal_composer_dependencies:
   - "drupal/facets:1.x-dev"
   - "drupal/content_browser:^1.0@alpha"
   - "drupal/matomo:^1.7"
+  - "drupal/pdf:1.x-dev"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
   - "islandora/islandora_demo:dev-8.x-1.x"
@@ -42,6 +43,7 @@ drupal_enable_modules:
   - facets
   - content_browser
   - matomo
+  - pdf
   - islandora_core_feature
   - controlled_access_terms_default_configuration
 drupal_trusted_hosts:

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -131,3 +131,16 @@
     chdir: "{{ drupal_core_path }}"
   register: set_search_api_config
   changed_when: "'Do you want to update site_id' in set_search_api_config.stdout"
+
+# pdf.js library
+- name: ensure tomcat directory exists
+  file:
+    path: "{{ drupal_external_libraries_directory }}/pdf.js"
+    state: directory
+
+- name: Unarchive pdf.js library.
+  unarchive:
+    src: "https://github.com/mozilla/pdf.js/releases/download/v2.0.943/pdfjs-2.0.943-dist.zip"
+    dest: "{{ drupal_external_libraries_directory }}/pdf.js"
+    creates: "{{ drupal_external_libraries_directory }}/pdf.js/build"
+    remote_src: yes


### PR DESCRIPTION
# What does this Pull Request do?
This PR installs the pdf drupal module and the required pdf.js library.

# How should this be tested?
* Get this PR
* Vagrant UP
* Verify that drupal pdf module is installed
* Verify that the drupal library is installed here `/var/www/html/drupal/web/libraries/pdf.js/build
/pdf.js`

# Additional Notes:
* https://github.com/Islandora-CLAW/islandora_demo/pull/16

# Interested parties
@kayakr @MarcusBarnes  @dannylamb 

@Islandora-CLAW/committers