### PR TITLE
Install PHP 7.1

### DIFF
--- a/crayfish.yml
+++ b/crayfish.yml
@@ -3,10 +3,14 @@
 - hosts: crayfish
   become: yes
 
+  vars:
+    php_version: 7.1
+
   roles:
     - name: geerlingguy.repo-remi
       when: ansible_os_family == "RedHat"
     - geerlingguy.apache
+    - geerlingguy.php-versions
     - geerlingguy.php
     - geerlingguy.git
     - geerlingguy.composer

--- a/crayfish.yml
+++ b/crayfish.yml
@@ -4,7 +4,7 @@
   become: yes
 
   vars:
-    php_version: 7.1
+    php_version: "7.1"
 
   roles:
     - name: geerlingguy.repo-remi

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,6 +7,9 @@
 - src: geerlingguy.apache
   version: 3.0.0
 
+- src: geerlingguy.php-versions
+  version: 2.1.5
+
 - src: geerlingguy.php
   version: 3.6.0
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
 
 php_packages_extra:
-  - libapache2-mod-php7.0
-  - php7.0-mysql
-  - php7.0-pgsql
+  - libapache2-mod-php7.1
+  - php7.1-mysql
+  - php7.1-pgsql

--- a/webserver.yml
+++ b/webserver.yml
@@ -4,7 +4,7 @@
   become: yes
 
   vars:
-    php_version: 7.1
+    php_version: "7.1"
 
   roles:
     - name: geerlingguy.repo-remi

--- a/webserver.yml
+++ b/webserver.yml
@@ -3,10 +3,14 @@
 - hosts: webserver
   become: yes
 
+  vars:
+    php_version: 7.1
+
   roles:
     - name: geerlingguy.repo-remi
       when: ansible_os_family == "RedHat"
     - geerlingguy.apache
+    - geerlingguy.php-versions
     - geerlingguy.php
     - geerlingguy.php-mysql
     - geerlingguy.git


### PR DESCRIPTION
Resolves: https://github.com/Islandora-CLAW/CLAW/issues/1007

Based on @kayakr's work [in that issue](https://github.com/Islandora-CLAW/CLAW/issues/1007#issuecomment-460475411)

I tried to get a single location to add/edit the `php_version` but it keep missing it and defaulting to PHP 7.2. 

If anyone has a suggestion please let me know, but Ansible variables are the stuff of nightmares. 

I have tested it in Ubuntu and Centos and it seems to work.

Once this is confirmed we should also update the composer.lock files for the Crayfish microservices and Crayfish-Commons as well.