### PR TITLE
changed Vagrant site name

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -25,7 +25,7 @@ drupal_db_name: drupal8
 drupal_db_backend: "{{ claw_db }}"
 drupal_db_host: "127.0.0.1"
 drupal_domain: "claw.dev"
-drupal_site_name: "Islandora-CLAW"
+drupal_site_name: "Islandora 8"
 drupal_install_profile: standard
 drupal_account_name: admin
 drupal_enable_modules:


### PR DESCRIPTION
Changes box name from Islandora-CLAW to Islandora 8.  
Addresses https://github.com/Islandora-CLAW/CLAW/issues/1020
