### PR TITLE
fixes https://github.com/Islandora-CLAW/CLAW/issues/1041

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -51,3 +51,4 @@ drupal_trusted_hosts:
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"
 drupal_public_filesystem: "{{ drupal_core_path }}/sites/default/files"
 drupal_external_libraries_directory: "{{ drupal_core_path }}/libraries"
+fedora_base_url: "http://localhost:8080/fcrepo/rest/"

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -13,7 +13,7 @@
         'fedora' => [
           'driver' => 'fedora',
           'config' => [
-            'root' => 'http://localhost:8080/fcrepo/rest/',
+            'root' => '{{ fedora_base_url }}',
           ],
         ],
       ];


### PR DESCRIPTION
What does this Pull Request do?
=======================
Add a variable for the fedora base url instead of having it hard coded.

What's new?
=========
A variable added in the inventory/vagrant/group_vars/webserver/drupal.yml for "fedora_base_url"
The new variable replaces the hard-coded value in roles/internal/webserver-app/tasks/drupal.yml

How should this be tested?
====================
From what I could tell of where the value was hardcoded, it referred to flysystem configuration.
The ansible code appeared to be updating a managed block in the settings.php file of the Drupal install. So after a fresh build, I verified the code block in the settings.php which produced 
```// BEGIN ANSIBLE MANAGED BLOCK
$settings['trusted_host_patterns'] = array(
  '^localhost$',
);
$settings['flysystem'] = [
  'fedora' => [
    'driver' => 'fedora',
    'config' => [
      'root' => 'http://localhost:8080/fcrepo/rest/',
    ],
  ],
];
// END ANSIBLE MANAGED BLOCK```

I also added an item with attached media and was able to verify that the item was present in the flysystem and fedora (ie. file is here: http://localhost:8000/_flysystem/fedora/2019-04/IMG_0059.JPG and http://localhost:8080/fcrepo/rest/2019-04/IMG_0059.JPG). 
If someone else could test on a fresh build, that'd be great. Also if I'm mistaken about what to test in order to verify that the configuration is still working correctly, please let me know and I am happy to do additional testing.

