### PR TITLE
Update requirements to pull new Crayfish

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -62,7 +62,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-crayfish
   name: Islandora-Devops.crayfish
-  version: 0.0.9
+  version: 0.1.0
 
 - src: https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon
   name: Islandora-Devops.drupal-openseadragon


### PR DESCRIPTION
I need the latest Crayfish which has the `/by_uri` endpoint in the Gemini service to integrate into Drupal