### PR TITLE
enable search block

### DIFF
--- a/post-install.yml
+++ b/post-install.yml
@@ -25,6 +25,8 @@
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim --bundle=islandora islandora_demo"
     - name: Add admin to fedoraAdmin role
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y urol fedoraadmin admin"
+    - name: Install islandora_search
+      command: "{{ drush_path }} --root {{ drupal_core_path }} -y en islandora_search"
 
     - name: Run migrations
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y -l localhost:{{ apache_listen_port }} --userid=1 mim --group=islandora"


### PR DESCRIPTION
**GitHub Issue**: (link)
* https://github.com/Islandora-CLAW/CLAW/issues/1100

# What does this Pull Request do?
* This pull request enable islandora_search module by default.

# How to test
* destroy the vagrant, including the claw-playbook folder
* Get this pr
* vagrant up
* Verify islandora_search is enabled
* Execute Test Cases 42 to 45 [here](https://docs.google.com/spreadsheets/d/1K0OlrN4xE-jRKX7-zJCFhL980YjQBQZyKqqCGyScyZ8/edit#gid=0)

# Interested parties
@Islandora-CLAW/committers
