### PR TITLE
use solr 7.x config for CLAW solr instance

### DIFF
--- a/inventory/vagrant/group_vars/solr.yml
+++ b/inventory/vagrant/group_vars/solr.yml
@@ -2,3 +2,5 @@
 
 solr_cores:
   - CLAW
+
+solr_install_path: /opt/solr

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -59,27 +59,6 @@
     owner: "{{ webserver_app_user }}"
     group: "{{ webserver_app_user }}"
 
-- name: Set default solr server to point to CLAW core
-  command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.core CLAW"
-  register: set_search_api_config
-  changed_when: "'Do you want to update' in set_search_api_config.stdout"
-
-- name: Get solr config files to copy
-  command: "find {{ webserver_document_root }}/drupal/web/modules/contrib/search_api_solr/solr-conf/6.x -type f"
-  register: files_to_copy
-  changed_when: false
-
-- name: Copy solr config files
-  copy:
-    src: "{{ item }}"
-    dest: "{{ solr_instance_conf_path }}"
-    owner: "{{ solr_user }}"
-    group: "{{ solr_user }}"
-    remote_src: True
-  with_items:
-   - "{{ files_to_copy.stdout_lines }}"
-  notify: restart solr
-
 - name: Import features
   command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,controlled_access_terms_default_configuration"
 

--- a/roles/internal/webserver-app/tasks/main.yml
+++ b/roles/internal/webserver-app/tasks/main.yml
@@ -17,3 +17,10 @@
   tags:
     - webserver-app
     - webserver-app-jwt
+
+- include: solr.yml
+  when: webserver_app_drupal
+  tags:
+    - webserver-app
+    - webserver-app-drupal
+

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Set default solr server to point to CLAW core
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.core CLAW"
+  register: set_search_api_config
+  changed_when: "'Do you want to update' in set_search_api_config.stdout"
+
+- name: Get solr config files to copy
+  command: "find {{ webserver_document_root }}/drupal/web/modules/contrib/search_api_solr/solr-conf/7.x -type f"
+  register: files_to_copy
+  changed_when: false
+
+- name: Copy solr config files
+  copy:
+    src: "{{ item }}"
+    dest: "{{ solr_instance_conf_path }}"
+    owner: "{{ solr_user }}"
+    group: "{{ solr_user }}"
+    remote_src: True
+  with_items:
+    - "{{ files_to_copy.stdout_lines }}"
+
+# https://www.drupal.org/project/search_api_solr/issues/3015993
+- name: Set solr_install_path in solrcore.properties
+  lineinfile:
+    path: /var/solr/data/CLAW/conf/solrcore.properties
+    regexp: '^solr\.install\.dir=.*$'
+    line: solr.install.dir={{ solr_install_path }}
+    state: present
+  notify: restart solr


### PR DESCRIPTION
Address this issue:
https://github.com/Islandora-CLAW/CLAW/issues/1069 (except the changing of the `<field name="_version_" type="plong" indexed="true" stored="true"/>`, which needs more info.)

## How should this be tested?
* Get the PR
* vagrant up
* verify that solr starts without issues: http://localhost:8983/solr
* verify that http://localhost:8000/admin/config/search/search-api/server/default_solr_server connects properly
* create some sample repo objects, verify they get indexed 

@kayakr 
@Islandora-Devops/committers 
