### PR TITLE
Configure gemini lookup and pseudo field bundles

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -53,3 +53,9 @@ drupal_public_filesystem: "{{ drupal_core_path }}/sites/default/files"
 drupal_external_libraries_directory: "{{ drupal_core_path }}/libraries"
 fedora_base_url: "http://localhost:8080/fcrepo/rest/"
 drupal_jsonld_remove_format: true
+drupal_gemini_pseudo_bundles:
+  - islandora_object:node
+  - image:media
+  - file:media
+  - audio:media
+  - video:media

--- a/post-install.yml
+++ b/post-install.yml
@@ -32,6 +32,13 @@
     - name: Set JSONLD Config
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml jsonld.settings remove_jsonld_format {{ drupal_jsonld_remove_format }}"
 
+    - name: Set Gemini URL
+      command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml islandora.settings gemini_url {{ crayfish_milliner_gemini_base_url }}"
+
+    - name: Set pseudo field bundles
+      command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml islandora.settings gemini_pseudo_bundles.{{ item.0 }} {{ item.1 }}"
+      with_indexed_items: "{{ drupal_gemini_pseudo_bundles }}"
+
     - name: Run migrations
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y -l localhost:{{ apache_listen_port }} --userid=1 mim --group=islandora"
 


### PR DESCRIPTION
**Resolves**: https://github.com/Islandora-CLAW/CLAW/issues/1129

**Relies on**: https://github.com/Islandora-CLAW/islandora/pull/138

Once the default islandora config is ready, then pull down this PR and vagrant up.

When its done, you should have a normal Islandora 8 site with Gemini URL set and a few default bundles with the Pseudo field enabled.

Attention:
@Islandora-Devops/committers 