### PR TITLE
Rename controlled access terms default configuration: Issue 1132

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -16,7 +16,7 @@ drupal_composer_dependencies:
   - "drupal/pdf:1.x-dev"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
-  - "islandora/islandora_defaults:dev-8.x-1.x"
+  - "islandora/islandora_defaults:dev-issue-1132"
 drupal_composer_project_package: "islandora/drupal-project:8.6.10"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -45,7 +45,7 @@ drupal_enable_modules:
   - matomo
   - pdf
   - islandora_core_feature
-  - controlled_access_terms_default_configuration
+  - controlled_access_terms_defaults
 drupal_trusted_hosts:
   - ^localhost$
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -16,7 +16,7 @@ drupal_composer_dependencies:
   - "drupal/pdf:1.x-dev"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
-  - "islandora/islandora_defaults:dev-issue-1132"
+  - "islandora/islandora_defaults:dev-8.x-1.x"
 drupal_composer_project_package: "islandora/drupal-project:8.6.10"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"

--- a/post-install.yml
+++ b/post-install.yml
@@ -85,7 +85,7 @@
 
     - name: Chown controlled access terms default configuration
       file:
-        dest: "{{ drupal_core_path }}/modules/contrib/controlled_access_terms/modules/controlled_access_terms_default_configuration"
+        dest: "{{ drupal_core_path }}/modules/contrib/controlled_access_terms/modules/controlled_access_terms_defaults"
         state: directory
         owner: "{{ webserver_app_user }}"
         group: "{{ webserver_app_user }}"

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -60,7 +60,7 @@
     group: "{{ webserver_app_user }}"
 
 - name: Import features
-  command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,controlled_access_terms_default_configuration"
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,controlled_access_terms_defaults"
 
 # masonry library is required by content_browser and not installed by composer due to issue 2971165.
 - name: Create drupal library directory.


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/1132

# What does this Pull Request do?

Replaces 'controlled_access_terms_default_configuration' with 'controlled_access_terms_defaults'.

# What's new?

* Renames 'controlled_access_terms_default_configuration' to 'controlled_access_terms_defaults'.
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No.

# How should this be tested?

* Apply the PR
* `vagrant up`
* Ensure everything still works.

# Additional Notes:
Once this is tested and both Islandora-CLAW/controlled_access_terms/pull/29 and Islandora-CLAW/islandora_defaults/pull/1 are merged we need to revert the `islandora/islandora_defaults:dev-issue-1132` in drupal.yml back to `islandora/islandora_defaults:dev-8.x-1.x` before merging.

# Interested parties
@dannylamb, @Islandora-CLAW/committers