### PR TITLE
Removes vm's audio

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--memory", $memory]
     vb.customize ["modifyvm", :id, "--cpus", $cpus]
     vb.customize ["modifyvm", :id, "--description", $virtualBoxDescription]
+    vb.customize ["modifyvm", :id, "--audio", "none"]
   end
 
   config.vm.provision :ansible do |ansible|


### PR DESCRIPTION
VM is triggering an action to take over control for the audio (mic & speakers). While this can be expected in a "Windows 10" VM or something, it should probably not exist in a headless VM. The base image has it so the best option at this point is to tell vagrant not to enable this in the first place. 

If you have headphones on you'll hear the speaker click or sound different when the system boots. I'm getting a notice from some software that my mic is being accessed by virtualbox whenever the VM is running. 