### PR TITLE
Unpinning from 1.0.0 to dev

### DIFF
--- a/inventory/vagrant/group_vars/crayfish.yml
+++ b/inventory/vagrant/group_vars/crayfish.yml
@@ -1,5 +1,5 @@
 ---
-
+crayfish_version_tag: dev
 crayfish_db: "{{ claw_db }}"
 
 crayfish_milliner_drupal_base_url: http://localhost:8000

--- a/inventory/vagrant/group_vars/karaf.yml
+++ b/inventory/vagrant/group_vars/karaf.yml
@@ -1,6 +1,6 @@
 ---
 
 # Comment in to build Alpaca from source
-# alpaca_from_source: yes
-# alpaca_version: your-branch-name
-# alpaca_clone_directory: /opt/alpaca
+ alpaca_from_source: yes
+ alpaca_version: dev
+ alpaca_clone_directory: /opt/alpaca

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -15,7 +15,7 @@ drupal_composer_dependencies:
   - "drupal/matomo:^1.7"
   - "drupal/pdf:1.x-dev"
   - "islandora/carapace:1.0.0"
-  - "islandora/islandora_defaults:1.0.0"
+  - "islandora/islandora_defaults:dev-8.x-1.x"
 drupal_composer_project_package: "islandora/drupal-project:8.6.10"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
@@ -58,3 +58,4 @@ drupal_gemini_pseudo_bundles:
   - file:media
   - audio:media
   - video:media
+openseadragon_composer_item: "islandora/openseadragon:dev-8.x-1.x"


### PR DESCRIPTION
# DO NOT MERGE

For https://github.com/Islandora-CLAW/CLAW/issues/1158

I've made this branch to pull all `dev` and `8.x-1.x` branches instead of using pinned versions of any Islandora 8 code. Can I get some folks to try out provisioning from the dev branch to test this?

If you can provision fine and it passes a quick smoke test, let me know and close this PR and https://github.com/Islandora-CLAW/CLAW/issues/1158