### PR TITLE
Drupal 8 7

### DIFF
--- a/inventory/vagrant/group_vars/crayfish.yml
+++ b/inventory/vagrant/group_vars/crayfish.yml
@@ -1,5 +1,5 @@
 ---
-
+crayfish_version_tag: dev
 crayfish_db: "{{ claw_db }}"
 
 crayfish_milliner_drupal_base_url: http://localhost:8000

--- a/inventory/vagrant/group_vars/karaf.yml
+++ b/inventory/vagrant/group_vars/karaf.yml
@@ -1,6 +1,6 @@
 ---
 
 # Comment in to build Alpaca from source
-# alpaca_from_source: yes
-# alpaca_version: your-branch-name
-# alpaca_clone_directory: /opt/alpaca
+ alpaca_from_source: yes
+ alpaca_version: dev
+ alpaca_clone_directory: /opt/alpaca

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -15,8 +15,8 @@ drupal_composer_dependencies:
   - "drupal/matomo:^1.7"
   - "drupal/pdf:1.x-dev"
   - "islandora/carapace:1.0.0"
-  - "islandora/islandora_defaults:dev-8.x-1.x"
-drupal_composer_project_package: "islandora/drupal-project:8.6.10"
+  - "islandora/islandora_defaults:dev-url-refactor"
+drupal_composer_project_package: "islandora/drupal-project:8.7"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -15,7 +15,7 @@ drupal_composer_dependencies:
   - "drupal/matomo:^1.7"
   - "drupal/pdf:1.x-dev"
   - "islandora/carapace:1.0.0"
-  - "islandora/islandora_defaults:1.0.0"
+  - "islandora/islandora_defaults:dev-8.x-1.x"
 drupal_composer_project_package: "islandora/drupal-project:8.6.10"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
@@ -58,3 +58,4 @@ drupal_gemini_pseudo_bundles:
   - file:media
   - audio:media
   - video:media
+openseadragon_composer_item: "islandora/openseadragon:dev-8.x-1.x"

--- a/post-install.yml
+++ b/post-install.yml
@@ -12,17 +12,9 @@
     # Some tomfoolery to get the demo module to install.
     # Subject to https://www.drupal.org/node/2599228
     # Should be fixed in Drupal 8.7
-    - name: Install islandora_defaults module (fail ok)
+    - name: Install islandora_defaults module
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y en islandora_defaults"
       ignore_errors: yes
-    - name: Update entities
-      command: "{{ drush_path }} --root {{ drupal_core_path }} -y entity:updates"
-    - name: Uninstall islandora_defaults module
-      command: "{{ drush_path }} --root {{ drupal_core_path }} -y pmu islandora_defaults"
-    - name: Install islandora_defaults module (should not fail)
-      command: "{{ drush_path }} --root {{ drupal_core_path }} -y en islandora_defaults"
-    - name: Import feature
-      command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim --bundle=islandora islandora_defaults"
     - name: Add admin to fedoraAdmin role
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y urol fedoraadmin admin"
     - name: Install islandora_search
@@ -38,6 +30,9 @@
     - name: Set pseudo field bundles
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml islandora.settings gemini_pseudo_bundles.{{ item.0 }} {{ item.1 }}"
       with_indexed_items: "{{ drupal_gemini_pseudo_bundles }}"
+
+    - name: Set media urls
+      command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml media.settings standalone_url true"
 
     - name: Run migrations
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y -l localhost:{{ apache_listen_port }} --userid=1 mim --group=islandora"
@@ -64,7 +59,7 @@
         group: "{{ webserver_app_user }}"
         mode: 0775
         recurse: yes
-    
+
     - name: Chown islandora core feature
       file:
         dest: "{{ drupal_core_path }}/modules/contrib/islandora/modules/islandora_core_feature"
@@ -91,3 +86,7 @@
         group: "{{ webserver_app_user }}"
         mode: 0775
         recurse: yes
+
+    - name: Clear cache
+      command: "{{ drush_path }} --root {{ drupal_core_path }} -y cr"
+


### PR DESCRIPTION
**GitHub Issues**
Resolves https://github.com/Islandora-CLAW/CLAW/issues/1110 and https://github.com/Islandora-CLAW/CLAW/issues/1095 and https://github.com/Islandora-CLAW/CLAW/issues/1144

Supersedes https://github.com/Islandora-Devops/claw-playbook/pull/108/files

Installs 8.7, clears the cache, and pulls in the latest Islandora module, which has a nice refactor to normalize how we're generating urls.