### PR TITLE
support search_api_solr 8.3, clean up

### DIFF
--- a/inventory/vagrant/group_vars/solr.yml
+++ b/inventory/vagrant/group_vars/solr.yml
@@ -4,3 +4,8 @@ solr_cores:
   - CLAW
 
 solr_install_path: /opt/solr
+
+solr_user: solr
+solr_instance_conf_path: /var/solr/data/CLAW/conf
+
+search_api_solr_ver: 3.1

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -9,7 +9,7 @@ drupal_composer_dependencies:
   - "drupal/devel:^2.0"
   - "drupal/rdfui:^1.0-beta1"
   - "drupal/restui:^1.16"
-  - "drupal/search_api_solr:^2.0"
+  - "drupal/search_api_solr:^{{ search_api_solr_ver }}"
   - "drupal/facets:^1.3"
   - "drupal/content_browser:^1.0@alpha"
   - "drupal/matomo:^1.7"

--- a/roles/internal/webserver-app/defaults/main.yml
+++ b/roles/internal/webserver-app/defaults/main.yml
@@ -10,7 +10,5 @@ webserver_app_jwt_config_path: /opt/islandora/configs/jwt
 webserver_app_drupal_config_path: /opt/islandora/configs/drupal
 
 webserver_app_user: "{% if ansible_os_family == 'RedHat' %}apache{% else %}www-data{% endif %}"
-solr_user: solr
-solr_instance_conf_path: /var/solr/data/CLAW/conf
 
 webserver_document_root: /var/www/html

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -25,7 +25,6 @@
     owner: "{{ solr_user }}"
     group: "{{ solr_user }}"
     remote_src: True
-    force: no
   with_items:
     - "{{ files_to_copy.stdout_lines }}"
 
@@ -37,3 +36,11 @@
     line: solr.install.dir={{ solr_install_path }}
     state: present
   notify: restart solr
+
+# We seem to be running into this issue https://www.drupal.org/project/search_api_solr/issues/3040862
+- name: Solrconfig.xml config changes
+  lineinfile:
+    path: "{{ solr_instance_conf_path }}/solrconfig.xml"
+    insertbefore: '<\/config>'
+    line: '<searchComponent name="spellcheck" class="solr.SpellCheckComponent" />'
+    state: present

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -5,11 +5,19 @@
   register: set_search_api_config
   changed_when: "'Do you want to update' in set_search_api_config.stdout"
 
+# Get if from source
+- name: Unarchive solr config
+  unarchive:
+    src: "https://ftp.drupal.org/files/projects/search_api_solr-8.x-{{ search_api_solr_ver }}.zip"
+    dest: /tmp
+    remote_src: yes
+
 - name: Get solr config files to copy
-  command: "find {{ webserver_document_root }}/drupal/web/modules/contrib/search_api_solr/solr-conf/7.x -type f"
+  command: "find /tmp/search_api_solr/solr-conf-templates/7.x -type f"
   register: files_to_copy
   changed_when: false
 
+# Don't replace config if it already exists
 - name: Copy solr config files
   copy:
     src: "{{ item }}"
@@ -17,13 +25,14 @@
     owner: "{{ solr_user }}"
     group: "{{ solr_user }}"
     remote_src: True
+    force: no
   with_items:
     - "{{ files_to_copy.stdout_lines }}"
 
 # https://www.drupal.org/project/search_api_solr/issues/3015993
 - name: Set solr_install_path in solrcore.properties
   lineinfile:
-    path: /var/solr/data/CLAW/conf/solrcore.properties
+    path: "{{ solr_instance_conf_path }}/solrcore.properties"
     regexp: '^solr\.install\.dir=.*$'
     line: solr.install.dir={{ solr_install_path }}
     state: present


### PR DESCRIPTION
**GitHub Issue**: (link)
https://github.com/Islandora-CLAW/CLAW/issues/1163

# What does this Pull Request do?
Installs and configures search_api_solr.


# How should this be tested?
* Get the PR
* vagrant up
* Create content
* Verify that it gets indexed and returned 

# Additional Notes:
Although the above works, " You are using outdated Solr configuration set. Please follow the instructions described in the INSTALL.md file for setting up Solr. " is being reported here: http://localhost:8000/admin/config/search/search-api/server/default_solr_server

Not sure what may be cause of error.  

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers
