### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,4 +34,4 @@ Any additional information that you think would be helpful when reviewing this
  PR.
 
 # Interested parties
-Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers
+Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1188

# What does this Pull Request do?

Updates the instructions to tag all committers in the pull request template, so it points to the committers for the Devops org instead of the main CLAW org. This was tested [here](https://github.com/Islandora-Devops/ansible-role-fits/pull/1#issuecomment-505488237)

# How should this be tested?

Did you receive a notification from the tag on this PR? Then the tag works! Review the template to make sure it's included properly.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers (fingers crossed)
