### PR TITLE
separate solr tasks so it can be deployed to its own server

### DIFF
--- a/inventory/vagrant/group_vars/solr.yml
+++ b/inventory/vagrant/group_vars/solr.yml
@@ -4,3 +4,6 @@ solr_cores:
   - CLAW
 
 solr_install_path: /opt/solr
+
+solr_user: solr
+solr_instance_conf_path: /var/solr/data/CLAW/conf

--- a/roles/internal/webserver-app/meta/main.yml
+++ b/roles/internal/webserver-app/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - geerlingguy.solr

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -1,30 +1,16 @@
 ---
 
-- name: Set default solr server to point to CLAW core
-  command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.core CLAW"
-  register: set_search_api_config
+
+# Only tasks related to configuring search_api_solr are put here
+# Solr server configuration should go into the solr playbook: https://github.com/Islandora-Devops/claw-playbook/blob/dev/solr.yml
+
+- name: Set default solr server host from hostvars
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.host {{ hostvars[groups['solr'][0]].ansible_ssh_host  }}"
+  register: set_search_api_config_host
   changed_when: "'Do you want to update' in set_search_api_config.stdout"
 
-- name: Get solr config files to copy
-  command: "find {{ webserver_document_root }}/drupal/web/modules/contrib/search_api_solr/solr-conf/7.x -type f"
-  register: files_to_copy
-  changed_when: false
+- name: Set default solr server to point to CLAW core
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.core CLAW"
+  register: set_search_api_config_core
+  changed_when: "'Do you want to update' in set_search_api_config.stdout"
 
-- name: Copy solr config files
-  copy:
-    src: "{{ item }}"
-    dest: "{{ solr_instance_conf_path }}"
-    owner: "{{ solr_user }}"
-    group: "{{ solr_user }}"
-    remote_src: True
-  with_items:
-    - "{{ files_to_copy.stdout_lines }}"
-
-# https://www.drupal.org/project/search_api_solr/issues/3015993
-- name: Set solr_install_path in solrcore.properties
-  lineinfile:
-    path: /var/solr/data/CLAW/conf/solrcore.properties
-    regexp: '^solr\.install\.dir=.*$'
-    line: solr.install.dir={{ solr_install_path }}
-    state: present
-  notify: restart solr

--- a/solr.yml
+++ b/solr.yml
@@ -13,3 +13,34 @@
       java_packages:
         - java-1.8.0-openjdk
     - geerlingguy.solr
+
+  tasks:
+    - name: Unarchive solr config
+      unarchive:
+        src: "https://ftp.drupal.org/files/projects/search_api_solr-8.x-2.0.zip"
+        dest: /tmp
+        remote_src: yes
+
+    - name: Get solr config files to copy
+      command: "find /tmp/search_api_solr/solr-conf/7.x -type f"
+      register: files_to_copy
+      changed_when: false
+
+    - name: Copy solr config files
+      copy:
+        src: "{{ item }}"
+        dest: "{{ solr_instance_conf_path }}"
+        owner: "{{ solr_user }}"
+        group: "{{ solr_user }}"
+        remote_src: True
+      with_items:
+        - "{{ files_to_copy.stdout_lines }}"
+
+    # https://www.drupal.org/project/search_api_solr/issues/3015993
+    - name: Set solr_install_path in solrcore.properties
+      lineinfile:
+        path: "{{ solr_instance_conf_path }}/solrcore.properties"
+        regexp: '^solr\.install\.dir=.*$'
+        line: solr.install.dir={{ solr_install_path }}
+        state: present
+      notify: restart solr


### PR DESCRIPTION
search_api_solr 8.3 is not quite working, thus this PR is stuck: https://github.com/Islandora-Devops/claw-playbook/pull/123.  Want to get the ansible changes to support indepndent solr server deployement in, thus this PR.  Will circle back to the search_api_solr 8.3 issue later on.

**GitHub Issue**: (link)
https://github.com/Islandora-CLAW/CLAW/issues/1197

# What does this Pull Request do?
* Supports installing solr on its own server.

# How should this be tested?
* Get the PR
* vagrant up
* Create content
* Verify that it gets indexed and returned 

In addition, testing the following is helpful.
* Get the PR
* Modify or create the following playbook:
```
---

- include: bootstrap.yml
  tags:
    - bootstrap
- include: solr.yml
```
* deploy and check that solr has been correctly installed

# Interested parties
@Islandora-CLAW/committers
