### PR TITLE
SQL-based Fedora object persistence (Issue 1244)

### DIFF
--- a/inventory/vagrant/group_vars/all/passwords.yml
+++ b/inventory/vagrant/group_vars/all/passwords.yml
@@ -15,3 +15,6 @@ islandora_syn_token: islandora
 
 # Cantaloupe
 cantaloupe_admin_password: islandora
+
+# Fedora
+fcrepo_db_password: islandora

--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -34,16 +34,6 @@ tomcat8_java_opts:
   - -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile={{ blazegraph_home_dir }}/conf/RWStore.properties
   - -Dcantaloupe.config={{ cantaloupe_symlink }}/cantaloupe.properties
   - -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-  # For Fedora MySQL object persistence
-  - -Dfcrepo.mysql.username={{ fcrepo_db_name }}
-  - -Dfcrepo.mysql.password={{ fcrepo_db_password }}
-  - -Dfcrepo.mysql.host={{ fcrepo_db_host }}
-  - -Dfcrepo.mysql.port={{ fcrepo_db_port }}
-  # For Fedora Postgresql object persistence
-  # - -Dfcrepo.postgresql.username={{ fcrepo_db_name }}
-  # - -Dfcrepo.postgresql.password={{ fcrepo_db_password }}
-  # - -Dfcrepo.postgresql.host={{ fcrepo_db_host }}
-  # - -Dfcrepo.postgresql.port={{ fcrepo_db_port }}
 
 fcrepo_syn_tomcat_home: "{{ tomcat8_home }}"
 fcrepo_syn_default_public_key_path: "{{ fcrepo_syn_tomcat_home }}/conf/public.key"

--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -6,6 +6,16 @@ tomcat8_users:
     roles:
       - manager-gui
 
+# For production use either "jdbc-mysql" or "jdbc-postgresql"
+#fcrepo_persistence: file-simple
+fcrepo_persistence: jdbc-mysql
+
+# Used for mysql or postgres object persistence.
+fcrepo_db_name: fcrepo
+fcrepo_db_user: fcrepo
+fcrepo_db_host: "127.0.0.1"
+fcrepo_db_port: "3306"
+
 tomcat8_java_opts:
   - -Djava.awt.headless=true
   - -Dfile.encoding=UTF-8
@@ -24,6 +34,16 @@ tomcat8_java_opts:
   - -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile={{ blazegraph_home_dir }}/conf/RWStore.properties
   - -Dcantaloupe.config={{ cantaloupe_symlink }}/cantaloupe.properties
   - -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+  # For Fedora MySQL object persistence
+  - -Dfcrepo.mysql.username={{ fcrepo_db_name }}
+  - -Dfcrepo.mysql.password={{ fcrepo_db_password }}
+  - -Dfcrepo.mysql.host={{ fcrepo_db_host }}
+  - -Dfcrepo.mysql.port={{ fcrepo_db_port }}
+  # For Fedora Postgresql object persistence
+  # - -Dfcrepo.postgresql.username={{ fcrepo_db_name }}
+  # - -Dfcrepo.postgresql.password={{ fcrepo_db_password }}
+  # - -Dfcrepo.postgresql.host={{ fcrepo_db_host }}
+  # - -Dfcrepo.postgresql.port={{ fcrepo_db_port }}
 
 fcrepo_syn_tomcat_home: "{{ tomcat8_home }}"
 fcrepo_syn_default_public_key_path: "{{ fcrepo_syn_tomcat_home }}/conf/public.key"

--- a/requirements.yml
+++ b/requirements.yml
@@ -68,9 +68,9 @@
   name: Islandora-Devops.drupal-openseadragon
   version: 1.0.0
 
-- src: https://github.com/seth-shaw-unlv/ansible-role-fcrepo
+- src: https://github.com/Islandora-Devops/ansible-role-fcrepo
   name: Islandora-Devops.fcrepo
-  version: issue-1244
+  version: 2.0.0
 
 - src: https://github.com/Islandora-Devops/ansible-role-fcrepo-syn
   name: Islandora-Devops.fcrepo-syn

--- a/requirements.yml
+++ b/requirements.yml
@@ -70,7 +70,7 @@
 
 - src: https://github.com/seth-shaw-unlv/ansible-role-fcrepo
   name: Islandora-Devops.fcrepo
-  version: dev-issue-1244
+  version: issue-1244
 
 - src: https://github.com/Islandora-Devops/ansible-role-fcrepo-syn
   name: Islandora-Devops.fcrepo-syn

--- a/requirements.yml
+++ b/requirements.yml
@@ -68,9 +68,9 @@
   name: Islandora-Devops.drupal-openseadragon
   version: 1.0.0
 
-- src: https://github.com/Islandora-Devops/ansible-role-fcrepo
+- src: https://github.com/seth-shaw-unlv/ansible-role-fcrepo
   name: Islandora-Devops.fcrepo
-  version: 1.0.0
+  version: dev-issue-1244
 
 - src: https://github.com/Islandora-Devops/ansible-role-fcrepo-syn
   name: Islandora-Devops.fcrepo-syn

--- a/tomcat.yml
+++ b/tomcat.yml
@@ -4,6 +4,14 @@
   become: yes
 
   roles:
+    - role: geerlingguy.java
+      when: "ansible_os_family == 'Debian'"
+      java_packages:
+        - openjdk-8-jdk
+    - role: geerlingguy.java
+      when: "ansible_os_family == 'RedHat'"
+      java_packages:
+        - java-1.8.0-openjdk
     - Islandora-Devops.tomcat8
     - Islandora-Devops.fcrepo
     - Islandora-Devops.fcrepo-syn


### PR DESCRIPTION
# DO NOT MERGE! Used for testing...

**GitHub Issue**: /Islandora-CLAW/CLAW/issues/1244

# What does this Pull Request do?

Used to test /Islandora-Devops/ansible-role-fcrepo/pull/8 by using Fedora's MySQL-based object persistence storage instead of the default simple file one.

# What's new?

* Change: the requirements to point to the ansible-role-fcrepo branch we're testing
* Added:
    - variables to tomcat8_java_opts necessary to use the MySQL storage
    - the fcrepo_persistence variable (set to jdbc-mysql)
    - fcrepo_db_password to the passwords config
    - Java roles (because idempotency for the Tomcat playbook is a good thing)
* Does this change require documentation to be updated? Maybe if we keep parts
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

- Apply the PR
- `vagrant up`
- `vagrant ssh`
- `mysql -u fcrepo -p fcrepo` (password: islandora)
- Ensure the fcrepo database is being populated
- Smoke test that Fedora is working properly

# Interested parties
@dannylamb, @whikloj, @Islandora-Devops/committers
