### PR TITLE
add epel repos for CentOS 7 to get cmake3 (issue 1247)

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,9 @@
 - src: geerlingguy.php-mysql
   version: 2.0.1
 
+- src: geerlingguy.repo-epel
+  version: 1.2.4
+
 - src: geerlingguy.repo-remi
   version: 1.2.0
 

--- a/tomcat.yml
+++ b/tomcat.yml
@@ -8,6 +8,8 @@
     - Islandora-Devops.fcrepo
     - Islandora-Devops.fcrepo-syn
     - Islandora-Devops.blazegraph
+    - name: geerlingguy.repo-epel
+      when: ansible_os_family == "RedHat"
     - Islandora-Devops.grok
     - Islandora-Devops.cantaloupe
     - Islandora-Devops.activemq


### PR DESCRIPTION
**GitHub Issue**: /Islandora-CLAW/CLAW/issues/1247

# What does this Pull Request do?

Adds the EPEL repos for CentOS 7 so that we can get cmake3 installed to build grok.

# What's new?

* Added requirement for geerlingguy.repo-epel
* Added repo-epel role to tomcat.yml before grok runs
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? Yes, geerlingguy.repo-epel
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Makes CentOS 7 work.

# How should this be tested?

- set your ISLANDORA_DISTRO to centos/7
- `vagrant up` and watch it fail on grok
- Apply the PR
- `vagrant up` and watch it work

# Interested parties
@Islandora-Devops/committers
