### PR TITLE
Fix python

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -14,7 +14,7 @@
       changed_when:
         - output.stdout != ""
         - output.stdout != "\r\n"
-      when: islandora_distro|default('') == "ubuntu/xenial64"
+      when: islandora_distro|default('') is match("ubuntu/")
 
     # Manually gather facts once python is installed
     - name: gather facts

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -6,6 +6,16 @@
   gather_facts: false
 
   tasks:
+    # python isn't installed by default on ubuntu 16.04 so we need
+    # to do that with the raw command before
+    - name: install python
+      raw: test -e /usr/bin/python || (apt-get update; apt-get install -y python;)
+      register: output
+      changed_when:
+        - output.stdout != ""
+        - output.stdout != "\r\n"
+      when: islandora_distro|default('') == "ubuntu/xenial64"
+
     # Manually gather facts once python is installed
     - name: gather facts
       setup:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -6,7 +6,7 @@
   gather_facts: false
 
   tasks:
-    # python isn't installed by default on ubuntu 16.04 so we need
+    # python isn't installed by default on ubuntu so we need
     # to do that with the raw command before
     - name: install python
       raw: test -e /usr/bin/python || (apt-get update; apt-get install -y python;)


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

The new Ubuntu 18.xx build fails for (I think) only non-Linux hosts due to a lack of python. This re-adds the raw task to install python on the guest first.

# How should this be tested?

If you are getting an error because of python missing, this should solve that and get claw-playbook building for you.

# Interested parties
@Islandora-Devops/committers @elizoller 
