### PR TITLE
Solr core

### DIFF
--- a/inventory/vagrant/group_vars/solr.yml
+++ b/inventory/vagrant/group_vars/solr.yml
@@ -1,7 +1,7 @@
 #solr_version: "6.6.0"
 
 solr_cores:
-  - CLAW
+  - ISLANDORA
 
 solr_install_path: /opt/solr
 

--- a/roles/internal/webserver-app/defaults/main.yml
+++ b/roles/internal/webserver-app/defaults/main.yml
@@ -11,6 +11,6 @@ webserver_app_drupal_config_path: /opt/islandora/configs/drupal
 
 webserver_app_user: "{% if ansible_os_family == 'RedHat' %}apache{% else %}www-data{% endif %}"
 solr_user: solr
-solr_instance_conf_path: /var/solr/data/CLAW/conf
+solr_instance_conf_path: /var/solr/data/{{ solr_cores[0] }}/conf
 
 webserver_document_root: /var/www/html

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Set default solr server to point to CLAW core
-  command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.core CLAW"
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.core {{ solr_cores[0] }}"
   register: set_search_api_config
   changed_when: "'Do you want to update' in set_search_api_config.stdout"
 
@@ -23,7 +23,7 @@
 # https://www.drupal.org/project/search_api_solr/issues/3015993
 - name: Set solr_install_path in solrcore.properties
   lineinfile:
-    path: /var/solr/data/CLAW/conf/solrcore.properties
+    path: /var/solr/data/{{ solr_cores[0] }}/conf/solrcore.properties
     regexp: '^solr\.install\.dir=.*$'
     line: solr.install.dir={{ solr_install_path }}
     state: present


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora-CLAW/CLAW/issues/1248)

# What does this Pull Request do?
Uses the first value in the list of solr cores in the `/inventory/vagrant/group_vars/solr.yml` in the webserver role

# What's new?
* Removes hardcoded "CLAW" name for the solr core and replaces with a reference to the already created solr_cores variable array
* changes the default Drupal solr core to the first one listed in the solr_cores of `/inventory/vagrant/group_vars/solr.yml`
* changes the path for solr core

# How should this be tested?
* pull down this PR
* change the value of "CLAW" in `/inventory/vagrant/group_vars/solr.yml` to something original. i tried DE_CLAW and NOT_CLAW 😉 
* vagrant up
* check that solr data is /var/solr/data/INSERT_WITTY_NAME_HERE
* check your solr config in drupal (http://localhost:8000/admin/config/search/search-api/server/default_solr_server) and see the name of your core 
* check the solr admin interface at http://localhost:8983/solr and be sure you have a correctly named core

# Interested parties
@Islandora-Devops/committers
