### PR TITLE
Pulling together all the bits for text extraction

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -63,7 +63,7 @@
   name: Islandora-Devops.cantaloupe
   version: 1.0.0
 
-- src: https://github.com/dannylamb/ansible-role-crayfish
+- src: https://github.com/Islandora-Devops/ansible-role-crayfish
   name: Islandora-Devops.crayfish
   version: 1.0.2
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/933

Pulls together
- https://github.com/Islandora-CLAW/Crayfish/pull/77
- https://github.com/Islandora-CLAW/islandora/pull/163
- https://github.com/Islandora-CLAW/islandora_defaults/pull/7
- https://github.com/Islandora-Devops/ansible-role-crayfish/pull/30

# What does this Pull Request do?

Installs a version of `islandora_text_extraction` that I've taken from @ajstanley and the UPEI crew and shuffled a few things around.

# What's new?
`islandora_text_extraction`, but with less files.  All remaining files are untouched from @ajstanley's original work, but I did delete some files that were no longer neccessary because...

* `pdftotext` is called in Hypercube now
* Some conditions have been replaced by just configuring the existing contexts we have differently
* All configuration has been split out into its own feature

# How should this be tested?

- Pull down this PR
- `rm -rf roles/external`
- `vagrant up`

Once successful, you should be able to trigger derivatives for both tesseract and pdftotext.  For tesseract:

- Make a node, give it a model of 'Page'
- Add a File media, upload a tiff, and tag it as an original file.

For pdftotext

- Make a node, give it a model of 'Digital Document'
- Add a File media, upload a PDF, and tag it as an original file

Of course this is all customizable through Context, but by default that's what will work.  You should get an `Extracted Text` media for both, which will have the text on it as a field.

# Additional Notes:
Ideally we'd ship with better solr config to have these text fields indexed by default.

# Interested parties
@Islandora-Devops/committers @ajstanley @dbernstein @Natkeeran 
