### PR TITLE
Add a required version plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you struggle with following the instructions for setting up the requirements 
 1. [VirtualBox](https://www.virtualbox.org/)
 2. [Vagrant](http://www.vagrantup.com/) (Known to work with 2.0.1 - 2.1.2)
 3. [git](https://git-scm.com/)
-4. [ansible](https://www.ansible.com/community) 2.3+
+4. [ansible](https://www.ansible.com/community) (restricted to versions 2.6.0 - 2.8.7)
 5. [virtualbox-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin (If targeting CENTOS)
 
 ## Variables

--- a/ansible-version.yml
+++ b/ansible-version.yml
@@ -1,0 +1,5 @@
+---
+  # Minimum version of ansible this playbook works with.
+  islandora_ansible_version_min: 2.6.0
+  # Maximum version of ansible this playbook works with.
+  islandora_ansible_version_max: 2.8.7

--- a/callback_plugins/ansible-version.py
+++ b/callback_plugins/ansible-version.py
@@ -1,0 +1,50 @@
+# -*- encoding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+import os
+import os.path
+import yaml
+from distutils.version import StrictVersion
+
+import ansible
+
+try:
+    # Version 2.0+
+    from ansible.plugins.callback import CallbackBase
+except ImportError:
+    CallbackBase = object
+
+
+class CallbackModule(CallbackBase):
+    def __init__(self):
+        self.minimum_version = StrictVersion('2.7.0')
+        self.maximum_version = StrictVersion('2.8.7')
+        self.load_from_main()
+        current_version = StrictVersion(ansible.__version__)
+        # Can't use `on_X` because this isn't forwards compatible with Ansible 2.0+
+        if current_version < self.minimum_version or current_version > self.maximum_version:
+            CallbackModule.print_red_bold(
+                "Islandora-Playbook restriction: only an Ansible between {minversion} and {maxversion} is supported."
+                .format(minversion=self.minimum_version, maxversion=self.maximum_version)
+            )
+            sys.exit(1)
+
+    @staticmethod
+    def print_red_bold(text):
+        print('\x1b[31;1m' + text + '\x1b[0m')
+
+    def load_from_main(self):
+        current_dir = os.getcwd()
+        version_file = os.path.join(current_dir, 'ansible-version.yml')
+        if os.path.exists(version_file):
+            with open(version_file, 'r') as fp:
+                versions = yaml.load(fp, Loader=yaml.SafeLoader)
+            try:
+                self.minimum_version = StrictVersion(versions['islandora_ansible_version_min'])
+            except KeyError:
+                pass
+            try:
+                self.maximum_version = StrictVersion(versions['islandora_ansible_version_max'])
+            except KeyError:
+                pass

--- a/callback_plugins/ansible-version.py
+++ b/callback_plugins/ansible-version.py
@@ -25,7 +25,7 @@ class CallbackModule(CallbackBase):
         # Can't use `on_X` because this isn't forwards compatible with Ansible 2.0+
         if current_version < self.minimum_version or current_version > self.maximum_version:
             CallbackModule.print_red_bold(
-                "Islandora-Playbook restriction: only an Ansible between {minversion} and {maxversion} is supported."
+                "Islandora-Playbook restriction: only an Ansible version between {minversion} and {maxversion} is supported."
                 .format(minversion=self.minimum_version, maxversion=self.maximum_version)
             )
             sys.exit(1)

--- a/callback_plugins/ansible-version.py
+++ b/callback_plugins/ansible-version.py
@@ -1,4 +1,6 @@
 # -*- encoding:utf-8 -*-
+# Copied from https://adamj.eu/tech/2016/08/19/restricting-the-ansible-version-in-use/
+# and edited to our use-case.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1343

# What does this Pull Request do?

Adds a plugin that enforces a minimum and maximum ansible version. The versions are loaded from a file `ansible-version.yml` in the root directory of the playbook. 

# How should this be tested?

I adjusted the ansible-version.yml to have either a minimum version greater than or a maximum version less than my current version and tried to run either
* `vagrant up`
* `ansible-playbook -i inventory/vagrant -uvagrant -e'islandora_distro=ubuntu/bionic64' playbook.yml`

If you run the vagrant up and the machine has already been built it will not fail and just start the machine, if the machine is not built then it will build the box and then fail.

For example, with ansible version 2.8.1
```
> ansible --version
ansible 2.8.1
  config file = /sw/var/www/DAM2/claw-playbook/ansible.cfg
  configured module search path = ['/Users/whikloj/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.8.1/libexec/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.5 (default, Nov  1 2019, 02:16:32) [Clang 11.0.0 (clang-1100.0.33.8)]
```

I changed `ansible-version.yml` to 
```
---
  # Minimum version of ansible this playbook works with.
  islandora_ansible_version_min: 2.8.2
  # Maximum version of ansible this playbook works with.
  islandora_ansible_version_max: 2.8.7
```

Then 
```
> ansible-playbook -i inventory/vagrant -uvagrant -e'islandora_distro=centos/7' playbook.yml
Islandora-Playbook restriction: only an Ansible version between 2.8.2 and 2.8.7 is supported.
```
or
```
> vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'ubuntu/bionic64'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'ubuntu/bionic64' version '20190225.0.0' is up to date...
==> default: Setting the name of the VM: Islandora CLAW Ansible
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 8000 (guest) => 8000 (host) (adapter 1)
    default: 8080 (guest) => 8080 (host) (adapter 1)
    default: 3306 (guest) => 3306 (host) (adapter 1)

...

- Islandora-Devops.fits (1.0.0) is already installed, skipping.
- Islandora-Devops.grok (2.0.0) is already installed, skipping.
- Islandora-Devops.karaf (1.0.0) is already installed, skipping.
- Islandora-Devops.keymaster (1.0.0) is already installed, skipping.
- Islandora-Devops.matomo (1.0.0) is already installed, skipping.
    default: Running ansible-playbook...
Islandora-Playbook restriction: only an Ansible version between 2.8.2 and 2.8.7 is supported.
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

# Interested parties
@Islandora-Devops/committers @g7morris 
