### PR TITLE
Pinning islandora_fits

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -18,7 +18,7 @@ drupal_composer_dependencies:
   - "drupal/rest_oai_pmh:^1.0"
   - "islandora/carapace:dev-8.x-3.x"
   - "islandora/islandora_defaults:dev-8.x-1.x"
-  - "islandora-rdm/islandora_fits:dev-master"
+  - "islandora-rdm/islandora_fits:dev-master#b8a126ebaa896402c6ba341047363a05857d0a60"
 drupal_composer_project_package: "islandora/drupal-project:8.7"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1405

# What does this Pull Request do?

Pins `islandora_fits` to the last known working version.

# How should this be tested?

#### Original Behaviour
Create a resource node and give it an original file.  You'll whitescreen with this in `/var/log/apache2/error.log`
```
[Tue Jan 21 14:27:43.053575 2020] [php7:notice] [pid 814] [client 10.0.2.2:48366] Uncaught PHP Exception Drupal\\Core\\Entity\\EntityStorageException: "Field field_fits_file is unknown." at /var/www/html/drupal/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php line 847, referer: http://localhost:8000/media/add/image?edit%5Bfield_media_of%5D%5Bwidget%5D%5B0%5D%5Btarget_id%5D=2
```

#### Behaviour with this PR
Save an Original File to a resource node and you'll have no whitescreen and nothing but your derivatives and happy times :rainbow: 

# Interested parties
@Islandora-Devops/committers
