### PR TITLE
[ENHANCEMENT] Make mem and cpu dynamic

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ end
 
 # Use whichever is larger, 1/2 the RAM or 4GB.
 $mem = [$mem / 2, 4096].max
+$detected_cpus = [$detected_cpus / 2, 1].max
 
 $cpus   = ENV.fetch("ISLANDORA_VAGRANT_CPUS", "1")
 $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", $mem)


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1413

# What does this Pull Request do?
1. Assess how much ram is available.
1. If "ISLANDORA_VAGRANT_MEMORY" is set use it. Otherwise If "ISLANDORA_VAGRANT_MEMORY" is blank use whichever is larger, 1/2 the RAM or 4GB.
1. If "ISLANDORA_VAGRANT_CPUS" is set use it. Otherwise if "ISLANDORA_VAGRANT_CPUS" is blank and there are no other VMS running set the CPU to 1/2 of the available CPUs, otherwise default to 1 core.

# What's new?
It looks up if VMS are running so that it doesn't over allocate the VM resources.

# How should this be tested?
* Test on a MAC, Linux, and windows machine to verify the test commands don't fail on a specific OS.
* Test if the 2 variable overrides work "ISLANDORA_VAGRANT_MEMORY" & "ISLANDORA_VAGRANT_CPUS"
* Test that the defaults are triggered when different VM is already running. This avoids issues will allocating too much RAM/CPUs collectively. It was brought up on the CLAW call as a check that would be useful.


```shell
# How many Cores
$ lscpu

# How much memory
$ free -h | gawk  '/Mem:/{print $2}'
```
# Additional Notes:
N/A

# Interested parties
@Islandora-Devops/committers
