### PR TITLE
[ENHANCEMENT] Dynamic drupal trusted hosts setting.

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -58,6 +58,7 @@ drupal_enable_modules:
 drupal_trusted_hosts:
   - ^localhost$
   - "{{ hostvars[groups['webserver'][0]].ansible_host }}"
+  - "^' . preg_quote($_SERVER['SERVER_NAME']) . '$"
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"
 drupal_public_filesystem: "{{ drupal_core_path }}/sites/default/files"
 drupal_external_libraries_directory: "{{ drupal_core_path }}/libraries"


### PR DESCRIPTION
# What does this Pull Request do?

This change allows direct access to Drupal via the virtual machine IP (or hostname) without a change to the Drupal `$settings['trusted_host_patterns']` variable.

# What's new?

Allows easier access to Islandora on the VM. However, this is not necessarily a safe change for a production installation.

# How should this be tested?

Access Islandora via a non-localhost address after VM creation.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
