### PR TITLE
Pins down grok to 3.1.0

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -56,6 +56,8 @@ fcrepo_version: "5.1.0"
 fcrepo_auth_header_name: "X-Islandora"
 fcrepo_syn_auth_header: "X-Islandora"
 
+grok_version_tag: v3.1.0
+
 cantaloupe_deploy_war: yes
 cantaloupe_deploy_war_path: "{{ tomcat8_home }}/webapps"
 cantaloupe_user: tomcat8


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1285

Also see https://github.com/Islandora-Devops/ansible-role-grok/pull/8, which updates the default variable in the role to match.

# What does this Pull Request do?

Updates Grok to v3.1.0, which does not seg fault when converting tiffs on Ubuntu 18.04 like v2.3.0 does.

# How should this be tested?

- Pull in this PR
- `vagrant up`

After it's done building, put a Tiff in your playbook's root directory, ssh in, and run convert on it.

- `vagrant ssh`
- `cd /home/ubuntu/islandora`
- `convert my.tiff my.jp2`

No seg fault!  You can run `identify` on the resulting jp2 to confirm it's ok.

# Interested parties
@Islandora-Devops/committers
