### PR TITLE
fits ansible separation into separate hosts

### DIFF
--- a/inventory/vagrant/group_vars/all/main.yml
+++ b/inventory/vagrant/group_vars/all/main.yml
@@ -39,3 +39,9 @@ mysql_users:
 # Used by both the webserver and crayfish role for CentOS.
 php_enablerepo: "remi-php72"
 php_packages_state: "latest"
+
+solr_cores:
+  - ISLANDORA
+
+apache_listen_port: 8000
+

--- a/inventory/vagrant/group_vars/all/passwords.yml
+++ b/inventory/vagrant/group_vars/all/passwords.yml
@@ -18,3 +18,4 @@ cantaloupe_admin_password: islandora
 
 # Fedora
 fcrepo_db_password: islandora
+fcrepo_db_root_password: "{{ islandora_db_root_password  }}"

--- a/inventory/vagrant/group_vars/crayfish.yml
+++ b/inventory/vagrant/group_vars/crayfish.yml
@@ -5,3 +5,5 @@ crayfish_db: "{{ claw_db }}"
 crayfish_fedora_base_url: "http://{{ hostvars[groups['tomcat'][0]].ansible_host }}:8080/fcrepo/rest"
 crayfish_drupal_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host }}:{{ apache_listen_port }}"
 crayfish_gemini_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host }}:{{ apache_listen_port }}/gemini"
+
+crayfits_web_service_url: "http://{{ hostvars[groups['tomcat'][0]].ansible_host }}:8080/fits/"

--- a/inventory/vagrant/group_vars/karaf.yml
+++ b/inventory/vagrant/group_vars/karaf.yml
@@ -15,3 +15,5 @@
  alpaca_gemini_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host  }}:{{ apache_listen_port }}/gemini/"
  alpaca_houdini_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host  }}:{{ apache_listen_port }}/houdini"
  alpaca_homarus_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host  }}:{{ apache_listen_port }}/homarus"
+ alpaca_fits_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host  }}:{{ apache_listen_port }}/crayfits"
+ alpaca_hypercube_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host  }}:{{ apache_listen_port }}/hypercube"

--- a/inventory/vagrant/group_vars/solr.yml
+++ b/inventory/vagrant/group_vars/solr.yml
@@ -1,8 +1,5 @@
 #solr_version: "6.6.0"
 
-solr_cores:
-  - ISLANDORA
-
 solr_install_path: /opt/solr
 
 solr_user: solr

--- a/inventory/vagrant/group_vars/webserver/apache.yml
+++ b/inventory/vagrant/group_vars/webserver/apache.yml
@@ -1,6 +1,5 @@
 ---
 
-apache_listen_port: 8000
 apache_create_vhosts: true
 apache_vhosts_filename: "islandora.conf"
 apache_remove_default_vhost: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -47,9 +47,9 @@
   name: Islandora-Devops.activemq
   version: master
 
-- src: https://github.com/Islandora-Devops/ansible-role-alpaca
+- src: https://github.com/Natkeeran/ansible-role-alpaca
   name: Islandora-Devops.alpaca
-  version: master
+  version: fits
 
 #- src: https://github.com/Islandora-Devops/ansible-role-apix
 #  name: Islandora-Devops.apix
@@ -63,9 +63,9 @@
   name: Islandora-Devops.cantaloupe
   version: master
 
-- src: https://github.com/Islandora-Devops/ansible-role-crayfish
+- src: https://github.com/Natkeeran/ansible-role-crayfish
   name: Islandora-Devops.crayfish
-  version: master
+  version: fits
 
 - src: https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon
   name: Islandora-Devops.drupal-openseadragon
@@ -83,9 +83,9 @@
   name: Islandora-Devops.tomcat8
   version: master
 
-- src: https://github.com/Islandora-Devops/ansible-role-fits
+- src: https://github.com/Natkeeran/ansible-role-fits
   name: Islandora-Devops.fits
-  version: master
+  version: fits
 
 - src: https://github.com/Islandora-Devops/ansible-role-grok
   name: Islandora-Devops.grok

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -106,3 +106,12 @@
     dest: "{{ drupal_external_libraries_directory }}/pdf.js"
     creates: "{{ drupal_external_libraries_directory }}/pdf.js/build"
     remote_src: yes
+
+- name: Download Islandora FITS
+  composer:
+    command: require
+    arguments: islandora-rdm/islandora_fits
+    working_dir: "{{ drupal_core_path }}/.."
+
+- name: Enable Islansdora FITS
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y en islandora_fits"


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

https://github.com/Islandora/documentation/issues/1429

# What does this Pull Request do?
Currently, the ansible-role-fits is written assuming a single server deployment.  Specifically, it deploys the Islandora Module (Webserver), Microservice (Crayfish?), and the FITS service (Tomcat) into Tomcat server (https://github.com/Islandora-Devops/islandora-playbook/blob/dev/tomcat.yml#L24).  

This causes issues for two server/multi server deployments, and will cause an issue for ISLE 8 development.  

This PR separates the ansible-role-fits into Webserver, Crayfish and Tomcat host tasks.  

# What's new?
As noted above, separation of above noted  ansible-role-fits role into separate target hosts.  

# How should this be tested?
This PR is intended for testing.  The PRs to roles will need to be merged separately, then this PR updated before it can be merged.  

Single Server Testing
vagrant up.

Multi Server Testing
(One option)
server 1: webserver + database + crayfish
server 2: karaf + database + tomcat + solr

# Additional Notes:
I am still testing this PR in a multi server setup.  Running into some issues :(

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
