### PR TITLE
Simplified Docker dev setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.1'
+
+services:
+
+  vm:
+    build:
+      context: ./docker/vm
+    container_name: vm
+    ports:
+      - 8000:8000
+      - 8080:8080
+      - 3306:3306
+      - 5432:5432
+      - 8983:8983
+      - 8161:8161
+    networks:
+      - islandora
+    privileged: true  
+    volumes:
+      - keys:/root/.ssh
+
+  ansible:
+    container_name: ansible
+    build:
+      context: ./docker/ansible
+    networks:
+      - islandora
+    depends_on: 
+      - vm
+    volumes:
+      - keys:/root/.ssh
+      - ./:/root/playbook:Z
+  
+networks:
+  islandora:
+    driver: bridge
+
+volumes:
+  keys:
+    driver: local
+    

--- a/docker/ansible/Dockerfile
+++ b/docker/ansible/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos:7.6.1810
+
+ENV ISLANDORA_DISTRO="centos/7" \
+    ANSIBLE_CONFIG=/root/playbook/ansible.cfg 
+
+WORKDIR /root/playbook
+
+RUN yum -y install epel-release && \
+    yum -y install git openssl openssh-clients python-pip python-devel python
+
+RUN pip install ansible==2.8.7
+
+COPY entrypoint.sh /bin/
+
+RUN chmod 700 /bin/entrypoint.sh
+
+ENTRYPOINT [ "/bin/entrypoint.sh" ]

--- a/docker/ansible/entrypoint.sh
+++ b/docker/ansible/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+ssh-keyscan -H vm > /root/.ssh/known_hosts
+
+ansible-galaxy install --role-file=/root/playbook/requirements.yml --roles-path=roles/external
+
+ansible-playbook \
+    -u root \
+    -i ./inventory/vagrant/hosts \
+    -e '@./docker/extra-vars.yml' \
+    -e ansible_ssh_host='vm' \
+    -e int_host='vm' \
+    --private-key /root/.ssh/id_rsa \
+    ./playbook.yml \
+    -l default
+
+## Keeps the container running forever, after Ansible finishes
+tail -f /dev/null

--- a/docker/extra-vars.yml
+++ b/docker/extra-vars.yml
@@ -1,0 +1,57 @@
+---
+
+# used to override variables in the playbook via the extra vars commandline
+# option.  Add your site specific vars here.  If you need values from
+# the terraform script, we will need to template them correctly.
+# 
+# Thoughts on templating: 
+#   - add the vars here with a default value and use subsequent calls on the
+#     provisioner call in terraform to override.
+# 
+#   - can we use functions in this file to do filters/templating?  Needs 
+#     testing.
+
+
+# internal_hostname - "-e int_host='somedomain'" can be passed via the cmdline to template externaly
+internal_hostname: "{{ int_host | default('localhost') }}"
+
+# external_hostname - "-e ext_host='somedomain'" can be passed via the cmdline to template externally
+external_hostname: "{{ ext_host | default('localhost') }}"
+
+# ansible mods
+ansible_host: vm
+ansible_port: 22
+ansible_ssh_private_key_file: /root/.ssh/id_rsa
+
+# php mods
+php_upload_max_filesize: 1024M
+php_post_max_size: 1024M
+php_max_execution_time: 300
+
+# TODO: Needs templating, maybe.  localhost may be ok.
+openseadragon_iiiv_server: "http://{{internal_hostname}}:8080/cantaloupe/iiif/2"
+
+# apache stuff
+apache_listen_port: "{{ ext_port | default('8000')}}"
+apache_vhosts:
+  - servername: "{{external_hostname}}"
+    documentroot: "/var/www/html/drupal/web"
+    allow_override: All
+    options: -Indexes +FollowSymLinks
+
+# drupal stuff
+drupal_domain: "{{external_hostname}}"
+drupal_trusted_hosts: 
+  - ^localhost$
+  - "{{ hostvars[groups['webserver'][0]].ansible_host }}"
+  - "{{external_hostname}}"
+
+# crayfish stuff
+crayfish_drupal_base_url: "http://{{ internal_hostname }}:{{ apache_listen_port }}"
+crayfish_gemini_base_url: "http://{{ internal_hostname }}:{{ apache_listen_port }}/gemini"
+
+# karaf stuff
+alpaca_milliner_base_url: "http://{{ internal_hostname  }}:{{ apache_listen_port }}/milliner/"
+alpaca_gemini_base_url: "http://{{ internal_hostname  }}:{{ apache_listen_port }}/gemini/"
+alpaca_houdini_base_url: "http://{{ internal_hostname }}:{{ apache_listen_port }}/houdini"
+alpaca_homarus_base_url: "http://{{ internal_hostname  }}:{{ apache_listen_port }}/homarus"

--- a/docker/vm/Dockerfile
+++ b/docker/vm/Dockerfile
@@ -1,0 +1,40 @@
+FROM centos:7.6.1810
+
+ENV container docker
+
+COPY sestatus /bin/
+
+RUN chmod 700 /bin/sestatus
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+	rm -f /lib/systemd/system/multi-user.target.wants/*;\
+	rm -f /etc/systemd/system/*.wants/*;\
+	rm -f /lib/systemd/system/local-fs.target.wants/*; \
+	rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+	rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+	rm -f /lib/systemd/system/basic.target.wants/*;\
+	rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN yum -y install \
+	--setopt=tsflags=nodocs \
+	--disableplugin=fastestmirror \
+	openssh-clients \
+	openssh-server \
+	openssl \
+	sudo \
+	initscripts
+
+# Authorize SSH Host
+RUN mkdir -p /root/.ssh && \
+	chmod 0700 /root/.ssh
+
+
+# Add the keys and set permissions
+RUN cat /dev/zero | ssh-keygen -q -N "" && \
+	chmod 600 /root/.ssh/id_rsa && \
+	chmod 600 /root/.ssh/id_rsa.pub && \
+	cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/docker/vm/sestatus
+++ b/docker/vm/sestatus
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Current mode:                   permissive"


### PR DESCRIPTION
Draft PR to demonstrate Islandora 8 in Docker, using a simplified setup containing an external Ansible variables file, and _no_ special Docker inventory, in contrast to #124

Creates and runs two Docker containers:

* An `ansible` container that, upon startup, runs ansible to install Islandora 8 to the `vm` container
* A `vm` container that plays the role of an empty Centos 7 box upon which Islandora 8 is installed via the `ansible` container.

## Motivation
* Providing the start of a development environment that would allow modeling of "services deployed on separate hosts" as containers.  
  * Right now, though, everything is installed to a single container whose role is analogous to the Vagrant VM.  It's a start, though.
* Because using Ansible + Vagrant + Virtualbox in Windows is possible, but impractically awkward

## To Test
* Make sure Docker is installed, as well as `docker-compose` (usually comes with the Docker distribution, e.g on Mac and Windows)
* Make sure the Islandora ports are free on your machine (e.g. there isn't another Islandora running on the same ports using Vagrant)
* Check out this PR, and in the repository's directory (`claw-playbook/`) do `docker-compose build`
* Do `docker-compose up -d`
* Watch the logs of the `ansible` container via ` docker logs -f ansible`.  That's the ansible output!  
* At this point, the only way to know it's done/ready is to look at the logs.  So watch the logs until Ansible is finished
  * Once the Ansible stops, the container will just run infinitely tailing /dev/null.  The container won't exit if it succeeds or fails.  It runs infinitely because that has been helpful for me in debugging Ansible issues.
* If Ansible succeeds, try logging into Islandora at the usual address `localhost:8000`, and poke around!  

## Tips and tricks

* You can hop onto any container while it's running by _docker exec -it <name> /bin/bash_.  For example, `docker exec -it vm /bin/bash`
* `docker-compose stop` will stop all containers, but keep state.  You can later on do a `docker-compose up vm` just to start the Islandora "vm" container. 
  * I haven't yet put the persisted state into volumes, so files/state are just written in the container.  As a result, all state disappears in a _poof_ once the containers are destroyed, e.g. via `docker-compose down`.  `docker-compose stop` preserves state.  
