### PR TITLE
Switch to use the PR branches

### DIFF
--- a/inventory/vagrant/group_vars/crayfish.yml
+++ b/inventory/vagrant/group_vars/crayfish.yml
@@ -1,5 +1,5 @@
 ---
-crayfish_version_tag: dev
+crayfish_version_tag: ISLANDORA-1224-homarus
 crayfish_db: "{{ claw_db }}"
 
 crayfish_fedora_base_url: "http://{{ hostvars[groups['tomcat'][0]].ansible_host }}:8080/fcrepo/rest"

--- a/requirements.yml
+++ b/requirements.yml
@@ -63,9 +63,9 @@
   name: Islandora-Devops.cantaloupe
   version: master
 
-- src: https://github.com/Islandora-Devops/ansible-role-crayfish
+- src: https://github.com/whikloj/ansible-role-crayfish
   name: Islandora-Devops.crayfish
-  version: master
+  version: issue-1224-homarus
 
 - src: https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon
   name: Islandora-Devops.drupal-openseadragon


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1224

** DO NOT MERGE FIRST **

The sequence for the related PRs is

*  https://github.com/Islandora/Crayfish-Commons/pull/39
*  update Crayfish PR to direct to dev-symfony-flex branch
*  Merge https://github.com/Islandora/Crayfish/pull/102
*  Merge https://github.com/Islandora-Devops/ansible-role-crayfish/pull/34
*  cut new version of Crayfish role
*  Merge this PR

# What does this Pull Request do?

This is purely to help test the associated PRs

# What's new?

Homarus is now in Symfony 4 

# How should this be tested?

Pull this branch
Delete your roles/external contents
`vagrant up`
Add images, audio and video files and ensure derivatives get properly generated for them

# Interested parties
@Islandora-Devops/committers
