### PR TITLE
Removing scaffolding plugin after install

### DIFF
--- a/post-install.yml
+++ b/post-install.yml
@@ -86,6 +86,13 @@
         mode: 0775
         recurse: yes
 
+    - name: Remove drupal scaffolding
+      composer:
+        command: remove
+        arguments: "drupal/core-composer-scaffold"
+        working_dir: "{{ drupal_composer_install_dir }}"
+      ignore_errors: yes
+
     - name: Clear cache
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y cr"
 

--- a/post-install.yml
+++ b/post-install.yml
@@ -86,6 +86,22 @@
         mode: 0775
         recurse: yes
 
+    - name: Chown default.settings.yml
+      file:
+        dest: "{{ drupal_core_path }}/sites/default/default.settings.yml"
+        state: file
+        owner: "{{ webserver_app_user }}"
+        group: "{{ webserver_app_user }}"
+        mode: 0664
+
+    - name: Chown default.services.yml
+      file:
+        dest: "{{ drupal_core_path }}/sites/default/default.services.yml"
+        state: file
+        owner: "{{ webserver_app_user }}"
+        group: "{{ webserver_app_user }}"
+        mode: 0664
+
     - name: Remove drupal scaffolding
       composer:
         command: remove

--- a/post-install.yml
+++ b/post-install.yml
@@ -88,7 +88,7 @@
 
     - name: Chown default.settings.yml
       file:
-        dest: "{{ drupal_core_path }}/sites/default/default.settings.yml"
+        dest: "{{ drupal_core_path }}/sites/default/default.settings.php"
         state: file
         owner: "{{ webserver_app_user }}"
         group: "{{ webserver_app_user }}"


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1448

# What does this Pull Request do?

Removes the scaffolding plugin after install since it's being problematic and it's already done its job.

# How should this be tested?

Without this PR, new environments fail when running `composer require`.  If you pull in this PR and build a box, `composer require` commands should succeed.

# Interested parties
@manez @DonRichards @Islandora-Devops/committers
