### PR TITLE
Allow disabled selinux

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -58,7 +58,7 @@
     # Parse sestatus down to one of two options.
     - name: Set selinux permissive fact
       set_fact:
-        selinux_permissive: "{{ sestatus_out.stdout|regex_search('Current mode.*(permissive|enforcing)')|regex_search('(permissive|enforcing)') }}"
+        selinux_permissive: "{{ sestatus_out.stdout|regex_search('Current mode.*(permissive|enforcing|disabled)')|regex_search('(permissive|enforcing|disabled)') }}"
       when: ansible_os_family == "RedHat"
 
     # Change Selinux to permissive


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1556

# What does this Pull Request do?

Accounts for SELinux having a status of disabled as well as permissive and enforcing.

# How should this be tested?

Really this needs a box which starts with a disabled SELinux and then run the playbook over-top of it. In which case it should not make any changes.

# Interested parties
@Islandora-Devops/committers and @ainsofs 
