### PR TITLE
Update branch master -> main

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -42,11 +42,11 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-activemq
   name: Islandora-Devops.activemq
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-alpaca
   name: Islandora-Devops.alpaca
-  version: master
+  version: main
 
 #- src: https://github.com/Islandora-Devops/ansible-role-apix
 #  name: Islandora-Devops.apix
@@ -54,48 +54,48 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-blazegraph
   name: Islandora-Devops.blazegraph
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-cantaloupe
   name: Islandora-Devops.cantaloupe
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-crayfish
   name: Islandora-Devops.crayfish
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon
   name: Islandora-Devops.drupal-openseadragon
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-fcrepo
   name: Islandora-Devops.fcrepo
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-fcrepo-syn
   name: Islandora-Devops.fcrepo-syn
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-tomcat8
   name: Islandora-Devops.tomcat8
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-fits
   name: Islandora-Devops.fits
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-grok
   name: Islandora-Devops.grok
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-karaf
   name: Islandora-Devops.karaf
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-keymaster
   name: Islandora-Devops.keymaster
-  version: master
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-matomo
   name: Islandora-Devops.matomo
-  version: master
+  version: main


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

ansible-galaxy fails because some of the requirement branches have been renamed to 'main' and no longer have a 'master' branch. This fix consistently uses the renamed 'main' branches for everything.

# How should this be tested?
Run ansible-galaxy install -r requirements.yml


# Additional Notes:
Requirements that experience the failure are: activemw, cantaloupe, drupal-openseadragon, fcrepo, fcrepo-syn, fits, grok, karaf, and keymaster.

# Interested parties
@Islandora-Devops/committers
