### PR TITLE
Issue 1561: Remove dependency on Name module

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -19,7 +19,7 @@ drupal_composer_dependencies:
   - "drupal/rest_oai_pmh:^1.0"
   - "drupal/transliterate_filenames:^1.3"
   - "islandora/carapace:dev-8.x-3.x"
-  - "islandora/islandora_defaults:dev-issue-1561"
+  - "islandora/islandora_defaults:dev-8.x-1.x"
   - "islandora-rdm/islandora_fits:dev-master"
 drupal_composer_project_package: "islandora/drupal-project:8.8.1"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -19,7 +19,7 @@ drupal_composer_dependencies:
   - "drupal/rest_oai_pmh:^1.0"
   - "drupal/transliterate_filenames:^1.3"
   - "islandora/carapace:dev-8.x-3.x"
-  - "islandora/islandora_defaults:dev-8.x-1.x"
+  - "islandora/islandora_defaults:dev-issue-1561"
   - "islandora-rdm/islandora_fits:dev-master"
 drupal_composer_project_package: "islandora/drupal-project:8.8.1"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -60,7 +60,7 @@
     group: "{{ webserver_app_user }}"
 
 - name: Import features
-  command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,controlled_access_terms_defaults,islandora_defaults,islandora_search"
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,islandora_defaults,islandora_search"
 
 
 # masonry library is required by content_browser and not installed by composer due to issue 2971165.


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1561

* https://github.com/Islandora/controlled_access_terms/pull/54
* https://github.com/Islandora/islandora_defaults/pull/36

# What does this Pull Request do?

Stops attempting to feature import the controlled_access_terms_defaults config; it isn't necessary.

# What's new?

* Stops attempting to feature import the controlled_access_terms_defaults config.

# How should this be tested?

* Get a fresh playbook
* apply the PR
* use either Ubuntu or CentOS 7, **not** the pre-built image
* vagrant up 🚀
* Build is successful!
* The person taxonomy exists with it's fields, but **not** the old Name module-based preferred and alternate name fields.

# Additional Notes:

**Once approved we need to revert the inventory edit to target the appropriate islandora_defaults branch.**

# Interested parties
@mjordan 
