### PR TITLE
remove dependency on geerlingguy drupal console ansible role because …

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -40,9 +40,6 @@
 - src: geerlingguy.drush
   version: 3.1.1
 
-- src: geerlingguy.drupal-console
-  version: 1.1.1
-
 - src: https://github.com/Islandora-Devops/ansible-role-activemq
   name: Islandora-Devops.activemq
   version: 1.0.1

--- a/webserver.yml
+++ b/webserver.yml
@@ -19,7 +19,6 @@
     - geerlingguy.git
     - geerlingguy.composer
     - geerlingguy.drush
-    - geerlingguy.drupal-console
     - geerlingguy.drupal
     - perms-fix
     - Islandora-Devops.drupal-openseadragon


### PR DESCRIPTION
…composer installs it just fine

**GitHub Issue**: https://github.com/Islandora/documentation/issues/1634  - thanks @klidifia! 

* Other Relevant Links

This was fixed on dev with https://github.com/Islandora/documentation/issues/1599

# What does this Pull Request do?

This should make  the "main" (release) work again. 

# What's new?

Removes drupal-console (composer installs it?)

# How should this be tested?

Check it out! Does it spin up?

# Additional Notes:

@dannylamb @klidifia @Islandora-Devops/committers 