### PR TITLE
Update PHP, Drupal, Drush, Composer for Composer 2 support

### DIFF
--- a/crayfish.yml
+++ b/crayfish.yml
@@ -4,7 +4,7 @@
   become: yes
 
   vars:
-    php_version: "7.2"
+    php_version: "7.4"
 
   roles:
     - name: geerlingguy.repo-remi

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -20,7 +20,7 @@ drupal_composer_dependencies:
   - "islandora/carapace:dev-8.x-3.x"
   - "islandora/islandora_defaults:dev-8.x-1.x"
   - "islandora-rdm/islandora_fits:dev-8.x-1.x"
-drupal_composer_project_package: "drupal/recommended-project:^8.9"
+drupal_composer_project_package: "drupal/recommended-project:8.9.7"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -4,7 +4,7 @@ drupal_build_composer_project: true
 drupal_composer_install_dir: /var/www/html/drupal
 drupal_core_owner: "{{ ansible_user }}"
 drupal_composer_dependencies:
-  - "zaporylie/composer-drupal-optimizations:*" 
+  - "zaporylie/composer-drupal-optimizations:^1.1" 
   - "drupal/devel:^2.0"
   - "drush/drush:^10.3"
   - "drupal/rdfui:^1.0-beta1"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -4,10 +4,9 @@ drupal_build_composer_project: true
 drupal_composer_install_dir: /var/www/html/drupal
 drupal_core_owner: "{{ ansible_user }}"
 drupal_composer_dependencies:
-  - "zaporylie/composer-drupal-optimizations:^1.0"
-  - "drupal/console:~1.0"
+  - "zaporylie/composer-drupal-optimizations:*" 
   - "drupal/devel:^2.0"
-  - "drush/drush:^9.0"
+  - "drush/drush:^10.3"
   - "drupal/rdfui:^1.0-beta1"
   - "drupal/restui:^1.16"
   - "drupal/search_api_solr:^4.1"
@@ -20,8 +19,8 @@ drupal_composer_dependencies:
   - "drupal/transliterate_filenames:^1.3"
   - "islandora/carapace:dev-8.x-3.x"
   - "islandora/islandora_defaults:dev-8.x-1.x"
-  - "islandora-rdm/islandora_fits:dev-master"
-drupal_composer_project_package: "islandora/drupal-project:8.8.1"
+  - "islandora-rdm/islandora_fits:dev-8.x-1.x"
+drupal_composer_project_package: "drupal/recommended-project:^8.9"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,8 +3,8 @@
 grok_version_tag: v3.1.0
 
 php_packages_extra:
-  - libapache2-mod-php7.2
-  - php7.2-mysql
-  - php7.2-pgsql
-  - php7.2-gd
+  - libapache2-mod-php7.4
+  - php7.4-mysql
+  - php7.4-pgsql
+  - php7.4-gd
 

--- a/webserver.yml
+++ b/webserver.yml
@@ -4,7 +4,7 @@
   become: yes
 
   vars:
-    php_version: "7.2"
+    php_version: "7.4"
 
   environment:
     COMPOSER_MEMORY_LIMIT: -1


### PR DESCRIPTION
**GitHub Issue**: (link)

[Composer issue when running "vagrant up" #1663](https://github.com/Islandora/documentation/issues/1663)

# What does this Pull Request do?

Vagrant / Ansible installation was failing due to composer being updated to version 2.0 in the Ubuntu base install.

Bumping version of composer packages revealed incompatibilities that needed to also be updated, including PHP to 7.4, Drush to 10.x, and Drupal Core to 8.9, which I did by changing the Drupal composer project to the officially-supported drupal/recommended-project.

# What's new?

* Drupal Core updated to 8.9.1
* Drush updated to 10.3.1
* PHP updated to 7.4.11
* Composer to 2.0.3
* Removed drupal/console , composer 2 compatibility is an open issue in the project. If needed console can be installed directly by the user until this is resolved. [drupal-console-extend-plugin: Compatibility with Composer 2](https://github.com/hechoendrupal/drupal-console-extend-plugin/issues/23)

* Does this change require documentation to be updated? 

No

* Does this change add any new dependencies? 

Just updates

* Does this change require any other modifications to be made to the repository

No

* Could this change impact execution of existing code?

None of these changes should affect Islandora behaviour, however, I observed the Ansible build step of installing packages via composer is significantly faster.

# How should this be tested?

*** Crayfish PR has been merged so edited out no-longer-needed testing steps ***


1. Initiate a build of the playbook via vagrant up.  (Thus, you must set the environment variable ISLANDORA_DISTRO=ubuntu/bionic64)
2. Observe the automated test results
3. Go through the process of creating nodes and media and ensure that everything works as expected.

# Interested parties
@Islandora-Devops/committers
 