### PR TITLE
Update Tomcat groups_vars for Cantaloupe 4+

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -72,5 +72,5 @@ cantaloupe_processor_jp2: OpenJpegProcessor
 cantaloupe_cache_source: FilesystemCache
 cantaloupe_cache_derivative: FilesystemCache
 cantaloupe_create_FilesystemCache_dir: yes
-cantaloupe_resolver_static: HttpResolver
+cantaloupe_resolver_static: HttpSource
 cantaloupe_HttpResolver_BasicLookupStrategy_url_prefix: ""


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1687

# What does this Pull Request do?

Changes a playbook variable for Cantaloupe that was changed in [Cantaloupe 3.4.x -> 4.0.x updates](https://github.com/cantaloupe-project/cantaloupe/blob/develop/UPGRADING.md#34x--40).

Depends on: https://github.com/Islandora-Devops/ansible-role-cantaloupe/pull/5

With https://github.com/Islandora-Devops/ansible-role-cantaloupe/pull/5 it resolves https://github.com/Islandora/documentation/issues/1687.

# What's new?

Cantaloupe 4.1.7!

# How should this be tested?

- Update `$VagrantBox` to use `ubuntu/bionic64` in `Vagrantfile`
- Update repo and branch for Cantaloupe playbook in `requirements.yml`

![Screenshot from 2020-11-12 19-46-20](https://user-images.githubusercontent.com/218561/99014077-f637d480-251f-11eb-9b05-710d75474edd.png)

- Add an Islandora Object, with an image, and you should see this:

![Screenshot_2020-11-12 Test Islandora 8](https://user-images.githubusercontent.com/218561/99014696-32b80000-2521-11eb-9d31-952b912be2f6.jpg)

- Go to http://localhost:8080/cantaloupe/admin and use `admin/islandora` and you should see this:
![Screenshot_2020-11-12 Cantaloupe Image Server](https://user-images.githubusercontent.com/218561/99014726-46fbfd00-2521-11eb-80f2-0cfcf47c030c.png)

# Additional Notes:

An issue with the Grok playbook came up while I was watching the Cantaloupe logs on this; `/usr/local/bin/opj_decompress` was not there. I noticed that the binaries that build `grok` from source have changed from being prefixed with `opj` to `grk`. Not sure why that playbook doesn't fail [here](https://github.com/Islandora-Devops/ansible-role-grok/blob/ce129a49351d31a0504f2389f23cf3d458ed4e24/tasks/install.yml#L51). Happy to create an issue for that, and get a PR in as well if y'all want.

# Interested parties

@seth-shaw-unlv @elizoller
