### PR TITLE
Change Drupal project version string to allow updates.

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -20,7 +20,7 @@ drupal_composer_dependencies:
   - "islandora/carapace:dev-8.x-3.x"
   - "islandora/islandora_defaults:dev-8.x-1.x"
   - "islandora-rdm/islandora_fits:dev-8.x-1.x"
-drupal_composer_project_package: "drupal/recommended-project:8.9.7"
+drupal_composer_project_package: "drupal/recommended-project:^8.9"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8


### PR DESCRIPTION
**GitHub Issue**: (link)


# What does this Pull Request do?

Changes the Drupal project string to not be pegged to a single Drupal version. This was preventing a core update due to a dependency on composer 1 in the composer.json. 

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

Changes the drupal_composer_project_package string in the vagrant inventory to "^8.9".

There was a Drupal core update to fix a security problem, 8.9.10. The version string as it now exists was preventing me from running composer update drupal/core due to a dependency (composer/installers) being incompatible with composer 2.

* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository 
 (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code?

No, the core update doesn't change any APIs.

# How should this be tested?

Run the playbook. Verify the Drupal admin page does not warn you of an outdated Drupal core version.

Run composer update:

```
composer update drupal/core 'drupal/core-*' --with-all-dependencies
```

Before this PR, this would fail due to a Composer 1 dependency. 
# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# tested partested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
