### PR TITLE
Ubuntu 20.04 Focal Fossa.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "4096")
 $hostname = ENV.fetch("ISLANDORA_VAGRANT_HOSTNAME", "islandora8")
 $virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "Islandora 8")
 
-# Available boxes are 'islandora/8', ubuntu/bionic64' and 'centos/7'
-# Use 'ubuntu/bionic64' or 'centos/7' to build a dev environment from scratch.
+# Available boxes are 'islandora/8' and 'ubuntu/focal64'
+# Use 'ubuntu/focal64' to build a dev environment from scratch.
 # Use 'islandora/8' if you just want to download a ready to run VM.
 $vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "islandora/8")
 

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -9,7 +9,7 @@
     # python isn't installed by default on ubuntu so we need
     # to do that with the raw command before
     - name: install python
-      raw: test -e /usr/bin/python || (apt-get update; apt-get install -y python;)
+      raw: test -e /usr/bin/python || (apt-get update; apt-get install -y python3;)
       register: output
       changed_when:
         - output.stdout != ""

--- a/inventory/vagrant/group_vars/database.yml
+++ b/inventory/vagrant/group_vars/database.yml
@@ -1,3 +1,4 @@
+ansible_python_interpreter: python3
 mysql_root_username: root
 mysql_root_password: "{{ islandora_db_root_password  }}"
 

--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -1,6 +1,6 @@
 ---
 
-tomcat8_users:
+tomcat9_users:
   - username: islandora
     password: "{{ islandora_tomcat_password }}"
     roles:
@@ -16,7 +16,7 @@ fcrepo_db_user: fcrepo
 fcrepo_db_host: "127.0.0.1"
 fcrepo_db_port: "3306"
 
-tomcat8_java_opts:
+tomcat9_java_opts:
   - -Djava.awt.headless=true
   - -Dfile.encoding=UTF-8
   - -server
@@ -35,7 +35,8 @@ tomcat8_java_opts:
   - -Dcantaloupe.config={{ cantaloupe_symlink }}/cantaloupe.properties
   - -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
 
-fcrepo_syn_tomcat_home: "{{ tomcat8_home }}"
+fcrepo_syn_tomcat_home: "{{ tomcat9_home }}"
+#fcrepo_syn_default_public_key_path: "/etc/tomcat9/public.key"
 fcrepo_syn_default_public_key_path: "{{ fcrepo_syn_tomcat_home }}/conf/public.key"
 
 fcrepo_syn_sites:
@@ -57,9 +58,9 @@ fcrepo_auth_header_name: "X-Islandora"
 fcrepo_syn_auth_header: "X-Islandora"
 
 cantaloupe_deploy_war: yes
-cantaloupe_deploy_war_path: "{{ tomcat8_home }}/webapps"
-cantaloupe_user: tomcat8
-cantaloupe_group: tomcat8
+cantaloupe_deploy_war_path: "{{ tomcat9_home }}/webapps"
+cantaloupe_user: tomcat
+cantaloupe_group: tomcat
 cantaloupe_admin_enabled: "true"
 cantaloupe_OpenJpegProcessor_path_to_binaries: /usr/local/bin
 cantaloupe_log_application_ConsoleAppender_enabled: "false"

--- a/post-install.yml
+++ b/post-install.yml
@@ -10,6 +10,35 @@
 
   tasks:
 
+    - name: Create a directory if it does not exist
+      ansible.builtin.file:
+        path: /etc/systemd/system/tomcat9.service.d
+        state: directory
+        mode: '0755'
+    
+    - name: Add Cantaloupe cache to Tomcat writable paths
+      lineinfile:
+        path: "/etc/systemd/system/tomcat9.service.d/override.conf"
+        regexp: 'var/cache/cantaloupe/$'
+        line: 'ReadWritePaths=/var/cache/cantaloupe/'
+        insertafter: EOF
+
+    - name: Add Cantaloupe log to Tomcat writable paths
+      lineinfile:
+        path: "/etc/systemd/system/tomcat9.service.d/override.conf"
+        regexp: 'var/log/cantaloupe/$'
+        line: 'ReadWritePaths=/var/log/cantaloupe'
+        insertafter: EOF
+
+    - name: restart daemon service
+      ansible.builtin.systemd:
+        daemon_reload: yes
+    
+    - name: start tomcat9
+      service:
+        name: tomcat9
+        state: started    
+
     - name: Add admin to fedoraAdmin role
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y urol fedoraadmin admin"
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -32,7 +32,7 @@
   version: 4.2.1
 
 - src: geerlingguy.java
-  version: 1.8.1
+  version: 1.10.0
 
 - src: geerlingguy.drupal
   version: 2.5.0
@@ -52,9 +52,9 @@
 #  name: Islandora-Devops.apix
 #  version: 0.0.1
 
-- src: https://github.com/Islandora-Devops/ansible-role-blazegraph
+- src: https://github.com/roblib/ansible-role-blazegraph
   name: Islandora-Devops.blazegraph
-  version: main
+  version: focal64
 
 - src: https://github.com/Islandora-Devops/ansible-role-cantaloupe
   name: Islandora-Devops.cantaloupe
@@ -68,25 +68,25 @@
   name: Islandora-Devops.drupal-openseadragon
   version: main
 
-- src: https://github.com/Islandora-Devops/ansible-role-fcrepo
+- src: https://github.com/roblib/ansible-role-fcrepo
   name: Islandora-Devops.fcrepo
-  version: main
+  version: focal64
 
-- src: https://github.com/Islandora-Devops/ansible-role-fcrepo-syn
+- src: https://github.com/roblib/ansible-role-fcrepo-syn
   name: Islandora-Devops.fcrepo-syn
-  version: main
+  version: focal64
 
-- src: https://github.com/Islandora-Devops/ansible-role-tomcat8
+- src: https://github.com/roblib/ansible-role-tomcat8
   name: Islandora-Devops.tomcat8
-  version: main
+  version: focal64
 
-- src: https://github.com/Islandora-Devops/ansible-role-fits
+- src: https://github.com/roblib/ansible-role-fits
   name: Islandora-Devops.fits
-  version: main
+  version: focal64
 
-- src: https://github.com/Islandora-Devops/ansible-role-grok
+- src: https://github.com/roblib/ansible-role-grok
   name: Islandora-Devops.grok
-  version: main
+  version: focal64
 
 - src: https://github.com/Islandora-Devops/ansible-role-karaf
   name: Islandora-Devops.karaf

--- a/requirements.yml
+++ b/requirements.yml
@@ -52,9 +52,9 @@
 #  name: Islandora-Devops.apix
 #  version: 0.0.1
 
-- src: https://github.com/roblib/ansible-role-blazegraph
+- src: https://github.com/Islandora-Devops/ansible-role-blazegraph
   name: Islandora-Devops.blazegraph
-  version: focal64
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-cantaloupe
   name: Islandora-Devops.cantaloupe
@@ -68,25 +68,25 @@
   name: Islandora-Devops.drupal-openseadragon
   version: main
 
-- src: https://github.com/roblib/ansible-role-fcrepo
+- src: https://github.com/Islandora-Devops/ansible-role-fcrepo
   name: Islandora-Devops.fcrepo
-  version: focal64
+  version: main
 
-- src: https://github.com/roblib/ansible-role-fcrepo-syn
+- src: https://github.com/Islandora-Devops/ansible-role-fcrepo-syn
   name: Islandora-Devops.fcrepo-syn
-  version: focal64
+  version: main
 
-- src: https://github.com/roblib/ansible-role-tomcat8
+- src: https://github.com/Islandora-Devops/ansible-role-tomcat8
   name: Islandora-Devops.tomcat8
-  version: focal64
+  version: main
 
-- src: https://github.com/roblib/ansible-role-fits
+- src: https://github.com/Islandora-Devops/ansible-role-fits
   name: Islandora-Devops.fits
-  version: focal64
+  version: main
 
-- src: https://github.com/roblib/ansible-role-grok
+- src: https://github.com/Islandora-Devops/ansible-role-grok
   name: Islandora-Devops.grok
-  version: focal64
+  version: main
 
 - src: https://github.com/Islandora-Devops/ansible-role-karaf
   name: Islandora-Devops.karaf


### PR DESCRIPTION
**GitHub Issue**: [Update playbook to Ubuntu 20.04 Focal64](https://github.com/Islandora/documentation/issues/1792)


# What does this Pull Request do?

Base Ubuntu version on 2020-04 FocalFossa, includes an update to Tomcat 9 and other roles.

# What's new?

Updated several external Islandora-Devops roles to be compatible with Ubuntu 20.04.


* Does this change add any new dependencies? 
No

* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 

The Islandora-Devops.tomcat8 role may be better renamed to tomcat9 or we go down the route to make it be either.

* Could this change impact execution of existing code?

This makes existing installations based on the playbook to be upgraded to a newer OS version. In place upgrades will need to be tested. 



# How should this be tested?

Run a full playbook installation, and tests to make sure object creation work as expected.

### Testing updated Ansible roels

This PR has been updated so that requirements.yml points to where the updated roles will live in the Islandora-Devops GitHub project. To test them before they are merged, roll back this PR's branch by 1 commit to have the requirements point to updated branches in https://github.com/roblib.

Test updating an existing playbook installation.


# Additional Notes:

### Dropping CentOS

> Do we still use CentOS? I noticed that building based on Centos does not work for Drupal 9 as the MySQL version is too old. Is this used by anyone going forward?

It was decided in [March 31, 2021 meeting](https://github.com/Islandora/documentation/wiki/March-31%2C-2021) that CentOS should no longer be supported due to lack of use and RedHat announcing that they were moving away from using it. References to CentOS were removed from the README in this PR but it hasn't been completely removed from the playbook and roles yet.

### Backwards compatibility question:

> The last update went from Xenial to Bionic without attempting to preserve the ability to build on Xenial. Is this ok to do again or should we add variables to allow for backwards compatibility?

It was decided in the [March 31, 2021 Meeting](https://github.com/Islandora/documentation/wiki/March-31%2C-2021) call that we should continue to move forward and support latest versions as the Playbook was never properly set up as an Ansible deployment platform.


# Interested parties

@Islandora-Devops/committers 

