### PR TITLE
Install profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This virtual machine **should not** be used in production **yet**.
 
 ### Base box
 
-By default, Vagrant creates a complete Islandora 8 1.1.0 instance. This version is the current offical release of Islandora.
+By default, Vagrant creates a complete Islandora 8 1.1.0 instance. This version is the current official release of Islandora.
 
 If you want to build a VM that pulls in the latest Islandora code (suitable for a development environment, for example), before running `vagrant up`, open `Vagrantfile` and change the `$vagrantBox` variable to 'ubuntu/focal64':
 
@@ -21,7 +21,24 @@ If you want to build a VM that pulls in the latest Islandora code (suitable for 
 # Use 'islandora/8' if you just want to download a ready to run VM.
 $vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "islandora/8")
 ```
+$$$ Drupal Profile
 
+YOu can also choose to install a specific Islandora Drupal install profile with the following variables:
+
+| Shell variable            | Vagrant variable | Ansible variable          | Description                                                                                      |
+|---------------------------|------------------|---------------------------|--------------------------------------------------------------------------------------------------|
+| ISLANDORA_PROFILE_PROJECT | $drupalProject   | islandora_profile_project | Composer project name + version of the Drupal profile to download.                               |
+|                           |                  |                           | Example: "islandora/drupal_profile:1.x-dev", "islandora/islandora_install_profile_demo:dev-main" |
+|                           |                  |                           |                                                                                                  |
+| ISLANDOA_PROFILE          | $drupalProfile   | islandora_profile.        | Machine name of Drupal profile to install. Usually just the second part composer project name.   |
+|                           |                  |                           | Example: "islandora_profile", "islandora_install_profile_demo"                                   |
+<dl>
+<dt>islandora_profile</dt>
+<dd>The standard Islandora profile with core defaults enabled, running on Drupal 9</dd>
+
+<dt>islandora_install_profile_demo</dt>
+<dd>An experimental distribution with additional features enabled by default and a Bootstrap-based theme. Runs on Drupal 8.9.</dd>
+</dl>
 
 ### System Resources
 
@@ -43,18 +60,18 @@ You can connect to the machine via the browser at [http://localhost:8000](http:/
 ### Drupal
 
 The default Drupal login details are:
-  
+
   * username: admin
   * password: islandora
 
 ### MySQL
-  
+
   * username: drupal8
   * password: islandora
 
 ### Fedora5
 
-The Fedora 5 REST API can be accessed at [http://localhost:8080/fcrepo/rest](http://localhost:8080/fcrepo/rest). 
+The Fedora 5 REST API can be accessed at [http://localhost:8080/fcrepo/rest](http://localhost:8080/fcrepo/rest).
 
 Authentication is done via [Syn](https://github.com/Islandora-CLAW/Syn) using [JWT](https://jwt.io) tokens.
 
@@ -67,11 +84,11 @@ You can access the Solr administration UI at http://localhost:8983/solr/
 You can connect to the machine via ssh:
 
   * `vagrant ssh`
-  
+
 ### ActiveMQ
 
 The default ActiveMQ login details are:
-  
+
   * username: admin
   * password: admin
 
@@ -83,17 +100,17 @@ You can access the Cantaloupe admin interface at: http://localhost:8080/cantalou
 
   * username: admin
   * password: islandora
-  
+
 You can access the IIIF interface at: http://localhost:8080/cantaloupe/iiif/2/
 
 ### JWT
 
-Islandora 8 uses JWT for authentication across the stack. Crayfish microservices, Fedora, and Drupal all use them. 
+Islandora 8 uses JWT for authentication across the stack. Crayfish microservices, Fedora, and Drupal all use them.
 Crayfish and Fedora have been set up to use a default token of `islandora` to make testing easier. To use it, just set
 the following header in HTTP requests:
 
   * `Authorization: Bearer islandora`
-  
+
 ### BlazeGraph (Bigdata)
 
 You can access the BlazeGraph interface at: http://localhost:8080/bigdata/
@@ -102,7 +119,7 @@ You have to select the islandora namespace in the [namespaces tab](http://localh
 
 ### FITS
 
-You can access the FITS Web Service at http://localhost:8080/fits/  
+You can access the FITS Web Service at http://localhost:8080/fits/
 
 ### Matomo
 
@@ -110,11 +127,11 @@ CLAW Playbook installs an instance of the [Matomo](https://matomo.org/) (formall
 
   * username: admin
   * password: islandora
- 
+
 ## Roadmap
 
 The playbook is in maintenance mode as new development is focused on [ISLE](https://islandora.github.io/documentation/installation/docker-compose/) for development and production.
- 
+
 ## Maintainers
 
 * [Jonathan Green](https://github.com/jonathangreen)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ $virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "I
 $vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "islandora/8")
 
 # You can tell Ansible to install a different Drupal install profile.
-$drupalProject = ENV.fetch("ISLANDORA_PROFILE_PROJECT", "roblib/islandora_profile:1.x-dev")
+$drupalProject = ENV.fetch("ISLANDORA_PROFILE_PROJECT", "islandora/islandora_profile:1.x-dev")
 $drupalProfile = ENV.fetch("ISLANDORA_PROFILE", "islandora_profile")
 
 # vagrant is the main user

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,10 @@ $virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "I
 # Use 'islandora/8' if you just want to download a ready to run VM.
 $vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "islandora/8")
 
+# You can tell Ansible to install a different Drupal install profile.
+$drupalProject = ENV.fetch("ISLANDORA_PROFILE_PROJECT", "roblib/islandora_profile:1.x-dev")
+$drupalProfile = ENV.fetch("ISLANDORA_PROFILE", "islandora_profile")
+
 # vagrant is the main user
 $vagrantUser = "vagrant"
 
@@ -41,7 +45,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 5432, host: 5432 # PostgreSQL
   config.vm.network :forwarded_port, guest: 8983, host: 8983 # Solr
   config.vm.network :forwarded_port, guest: 8161, host: 8161 # Activemq
-  config.vm.network :forwarded_port, guest: 8081, host: 8081 # API-X
+
 
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", $memory]
@@ -63,7 +67,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.host_vars = {
         "all" => { "ansible_ssh_user" => $vagrantUser }
       }
-      ansible.extra_vars = { "islandora_distro" => $vagrantBox }
+      ansible.extra_vars = { "islandora_distro" => $vagrantBox,
+                             "islandora_profile_project" => $drupalProject,
+                             "islandora_profile" => $drupalProfile}
     end
   end
 

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -2,7 +2,7 @@
 
 drupal_build_composer_project: true
 drupal_composer_install_dir: /var/www/html/drupal
-drupal_composer_project_package: roblib/islandora-project
+drupal_composer_project_package: roblib/islandora-project:bd-dev
 
 drupal_core_owner: "{{ ansible_user }}"
 drupal_composer_dependencies: ""
@@ -14,7 +14,7 @@ drupal_db_backend: "{{ claw_db }}"
 drupal_db_host: "127.0.0.1"
 drupal_domain: "claw.dev"
 drupal_site_name: "Islandora 8"
-drupal_install_profile: islandora_profile
+drupal_install_profile: islandora_install_profile_demo
 drupal_account_name: admin
 
 drupal_enable_modules:
@@ -26,6 +26,7 @@ drupal_trusted_hosts:
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"
 drupal_public_filesystem: "{{ drupal_core_path }}/sites/default/files"
 drupal_external_libraries_directory: "{{ drupal_core_path }}/libraries"
+drupal_content_sync_path: "{{ drupal_composer_install_dir }}/content/sync"
 fedora_base_url: "http://{{ hostvars[groups['tomcat'][0]].ansible_host }}:8080/fcrepo/rest/"
 drupal_jsonld_remove_format: true
 drupal_gemini_pseudo_bundles:

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -2,32 +2,11 @@
 
 drupal_build_composer_project: true
 drupal_composer_install_dir: /var/www/html/drupal
+drupal_composer_project_package: roblib/islandora-project
+
 drupal_core_owner: "{{ ansible_user }}"
-drupal_composer_dependencies:
-  - "zaporylie/composer-drupal-optimizations:^1.1" 
-  - "drupal/devel:^4.0"
-  - "drupal/core-dev:^9.1"
-  - "drush/drush:^10.3"
-  - "drupal/rdfui:^1.0-beta1"
-  - "drupal/restui:^1.16"
-  - "drupal/search_api_solr:^4.1"
-  - "drupal/facets:^1.6"
-  - "drupal/content_browser:^1.0@alpha"
-  - "drupal/matomo:^1.7"
-  - "drupal/pdf:1.x-dev"
-  - "drupal/admin_toolbar:^2.0"
-  - "drupal/rest_oai_pmh:^1.0@beta"
-  - "drupal/transliterate_filenames:^1.3"
-  - "easyrdf/easyrdf:^1.1"
-  - "drupal/features:^3.11"
-  - "drupal/jwt:^1.0@beta"
-  - "drupal/flysystem:^2.0@alpha"
-  - "drupal/context:^4.0@beta"
-  - "islandora/controlled_access_terms:dev-8.x-1.x"
-  - "islandora/islandora_defaults:dev-8.x-1.x"
-  - "islandora-rdm/islandora_fits:dev-8.x-1.x"
-drupal_composer_project_package: "drupal/recommended-project:^9.1"
-drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
+drupal_composer_dependencies: ""
+drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction --repository='{\"type\": \"vcs\", \"url\": \"https://github.com/roblib/islandora-project\"}'"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8
 drupal_db_name: drupal8
@@ -35,33 +14,12 @@ drupal_db_backend: "{{ claw_db }}"
 drupal_db_host: "127.0.0.1"
 drupal_domain: "claw.dev"
 drupal_site_name: "Islandora 8"
-drupal_install_profile: standard
+drupal_install_profile: islandora_profile
 drupal_account_name: admin
+
 drupal_enable_modules:
-  - rdf
-  - responsive_image
-  - syslog
-  - serialization
-  - basic_auth
-  - rest
-  - restui
-  - devel
-  - features
-  - search_api_solr
-  - facets
-  - content_browser
-  - matomo
-  - pdf
-  - admin_toolbar
-  - transliterate_filenames
-  - islandora_defaults
-  - controlled_access_terms_defaults
-  - islandora_defaults
-  - islandora_fits
-  - islandora_breadcrumbs
-  - islandora_iiif
-  - islandora_oaipmh
   - islandora_search
+
 drupal_trusted_hosts:
   - ^localhost$
   - "{{ hostvars[groups['webserver'][0]].ansible_host }}"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -23,6 +23,7 @@ drupal_enable_modules:
 drupal_trusted_hosts:
   - ^localhost$
   - "{{ hostvars[groups['webserver'][0]].ansible_host }}"
+drupal_settings_file: "{{ drupal_core_path }}/sites/default/settings.php"
 drupal_trusted_hosts_file: "{{ drupal_core_path }}/sites/default/settings.php"
 drupal_public_filesystem: "{{ drupal_core_path }}/sites/default/files"
 drupal_external_libraries_directory: "{{ drupal_core_path }}/libraries"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -2,12 +2,12 @@
 
 drupal_build_composer_project: true
 drupal_composer_install_dir: /var/www/html/drupal
-drupal_composer_project_package: roblib/islandora-project:main-dev
+drupal_composer_project_package: islandora/islandora-project:main-dev
 
 drupal_core_owner: "{{ ansible_user }}"
 drupal_composer_dependencies:
   - "--with-all-dependencies {{ islandora_profile_project }}"
-drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction --repository='{\"type\": \"vcs\", \"url\": \"https://github.com/roblib/islandora-project\"}'"
+drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8
 drupal_db_name: drupal8

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -2,10 +2,11 @@
 
 drupal_build_composer_project: true
 drupal_composer_install_dir: /var/www/html/drupal
-drupal_composer_project_package: roblib/islandora-project:bd-dev
+drupal_composer_project_package: roblib/islandora-project:main-dev
 
 drupal_core_owner: "{{ ansible_user }}"
-drupal_composer_dependencies: ""
+drupal_composer_dependencies:
+  - "--with-all-dependencies {{ islandora_profile_project }}"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction --repository='{\"type\": \"vcs\", \"url\": \"https://github.com/roblib/islandora-project\"}'"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8
@@ -14,7 +15,7 @@ drupal_db_backend: "{{ claw_db }}"
 drupal_db_host: "127.0.0.1"
 drupal_domain: "claw.dev"
 drupal_site_name: "Islandora 8"
-drupal_install_profile: islandora_install_profile_demo
+drupal_install_profile: "{{ islandora_profile }}"
 drupal_account_name: admin
 
 drupal_enable_modules:

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -17,6 +17,9 @@
           ],
         ],
       ];
+      
+      global $content_directories;
+      $content_directories['sync'] = "{{ drupal_composer_install_dir }}/content/sync";
     path: "{{ drupal_trusted_hosts_file }}"
     marker: // {mark} ANSIBLE MANAGED BLOCK
 
@@ -83,15 +86,13 @@
   become: false
   when: ansible_os_family == "RedHat"
 
-  // Content sync settings
-  name: Create content sync directory.
+# Content sync settings
+- name: Create content sync directory.
   file:
     path: "{{ drupal_composer_install_dir }}/content/sync"
     state: directory
     owner: "{{ webserver_app_user }}"
     group: "{{ webserver_app_user }}"
     recurse: yes
-  name: ADd content sync directory setting
-  //global $content_directories;
-  //$content_directories['sync'] = "/var/www/drupal/content/sync";
+
 

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -100,3 +100,10 @@
   register: enable_bartik
   changed_when: "'Successfully enabled theme: bartik' in enable_bartik.stdout"
 
+# Ensure correct broker and gemini URLs
+- name: Set broker URL
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset islandora.settings broker_url tcp://localhost:61613"
+
+- name: Set Gemini URL
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset islandora.settings gemini_url http://localhost:8000"
+   

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -17,7 +17,7 @@
           ],
         ],
       ];
-      
+
       global $content_directories;
       $content_directories['sync'] = "{{ drupal_composer_install_dir }}/content/sync";
     path: "{{ drupal_trusted_hosts_file }}"
@@ -95,4 +95,8 @@
     group: "{{ webserver_app_user }}"
     recurse: yes
 
+- name: Enable Bartik theme
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y theme:enable bartik"
+  register: enable_bartik
+  changed_when: "'Successfully enabled theme: bartik' in enable_bartik.stdout"
 

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -83,3 +83,15 @@
   become: false
   when: ansible_os_family == "RedHat"
 
+  // Content sync settings
+  name: Create content sync directory.
+  file:
+    path: "{{ drupal_composer_install_dir }}/content/sync"
+    state: directory
+    owner: "{{ webserver_app_user }}"
+    group: "{{ webserver_app_user }}"
+    recurse: yes
+  name: ADd content sync directory setting
+  //global $content_directories;
+  //$content_directories['sync'] = "/var/www/drupal/content/sync";
+

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -43,27 +43,6 @@
 - name: Import features
   command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,islandora_defaults,islandora_search"
 
-
-# masonry library is required by content_browser and not installed by composer due to issue 2971165.
-- name: Create drupal library directory.
-  file:
-    state: directory
-    path: "{{ drupal_external_libraries_directory }}"
-    owner: "{{ webserver_app_user }}"
-    group: "{{ webserver_app_user }}"
-
-- name: Unarchive masonry library.
-  unarchive:
-    src: "https://github.com/desandro/masonry/archive/v3.3.2.zip"
-    dest: "{{ drupal_external_libraries_directory }}"
-    creates: "{{ drupal_external_libraries_directory }}/masonry"
-    remote_src: yes
-
-- name: Rename masonry directory.
-  command: mv "{{ drupal_external_libraries_directory }}/masonry-3.3.2" "{{ drupal_external_libraries_directory }}/masonry"
-  args:
-    creates: "{{ drupal_external_libraries_directory }}/masonry"
-
 # Set Matomo Settings
 - name: Set Matomo site id.
   command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set matomo.settings site_id 1"


### PR DESCRIPTION
**GitHub Issue**: [Make Islandora a Drupal Distribution](https://github.com/Islandora/documentation/issues/1194)

# What does this Pull Request do?

Uses a composer project to set up a Drupal project, which then imports an install profile that can be set in a variable. Available profiles are the [standard profile](https://github.com/islandora-devops/islandora_profile) and the [Born Digital-derived install profile](https://github.com/Islandora-Devops/islandora_install_profile_demo).

# What's new?

Uses a composer profile that supports 3rd-party libraries and install profiles, which the Drupal recommended-project does not. Retrieves and installs a Drupal install profile specified in a Vagrant or Ansible variable.

Composer then recursively fetches the Install Profile and all requirements, so those are no longer listed in the playbook.

 possible side effects.

All new install profile with modules and theme, so new sites will be fully different in look and feel and behaviour.

# How should this be tested?

Before running a playbook, set the following variables in your Unix shell or Vagrantfile

ISLANDORA_DRUPAL_PROFILE_PROJECT to either islandora/islandora_profile:1.x-dev or islandora/islandora_install_profile_demo:dev-main
ISLANDORA_DRUPAL_PROFILE to either islandora_profile or islandora_install_profile_demo

Test by running a playbook install and creating nodes and media to ensure that the site behaves as expected. Some forms will be different as they have been altered by Born Digital.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
