### PR TITLE
Use semantic versioning in islandora drupal modules.

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -23,8 +23,8 @@ drupal_composer_dependencies:
   - "drupal/jwt:^1.0@beta"
   - "drupal/flysystem:^2.0@alpha"
   - "drupal/context:^4.0@beta"
-  - "islandora/controlled_access_terms:^2.x"
-  - "islandora/islandora_defaults:^2.x"
+  - "islandora/controlled_access_terms:^2"
+  - "islandora/islandora_defaults:^2"
   - "islandora-rdm/islandora_fits:dev-8.x-1.x"
 drupal_composer_project_package: "drupal/recommended-project:^9.1"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
@@ -76,4 +76,4 @@ drupal_gemini_pseudo_bundles:
   - file:media
   - audio:media
   - video:media
-openseadragon_composer_item: "islandora/openseadragon:^2.x"
+openseadragon_composer_item: "islandora/openseadragon:^2"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -23,8 +23,8 @@ drupal_composer_dependencies:
   - "drupal/jwt:^1.0@beta"
   - "drupal/flysystem:^2.0@alpha"
   - "drupal/context:^4.0@beta"
-  - "islandora/controlled_access_terms:dev-8.x-1.x"
-  - "islandora/islandora_defaults:dev-8.x-1.x"
+  - "islandora/controlled_access_terms:^2.x"
+  - "islandora/islandora_defaults:^2.x"
   - "islandora-rdm/islandora_fits:dev-8.x-1.x"
 drupal_composer_project_package: "drupal/recommended-project:^9.1"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
@@ -76,4 +76,4 @@ drupal_gemini_pseudo_bundles:
   - file:media
   - audio:media
   - video:media
-openseadragon_composer_item: "islandora/openseadragon:dev-8.x-1.x"
+openseadragon_composer_item: "islandora/openseadragon:^2.x"


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1907

* Other Relevant Links: Discussed at [today's tech call](https://github.com/Islandora/documentation/wiki/October-6%2C-2021)

# What does this Pull Request do?

Switch composer requirements. Use the latest 2.x release (^2) instead of the 8.x-1.x branch.

# How should this be tested?

If composer can find a good set of dependencies, it should be a-ok. If you run the playbook you should get the latest 2x releases of islandora defaults, openseadragon, and controlled access terms.


# Interested parties
@bseeger @seth-shaw-unlv 