### PR TITLE
Fix broken update process from all-in-one

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -19,15 +19,11 @@ drupal_composer_dependencies:
   - "drupal/rest_oai_pmh:^1.0@beta"
   - "drupal/transliterate_filenames:^1.3"
   - "easyrdf/easyrdf:^1.1"
-  - "drupal/features:^3.11"
-  - "drupal/jwt:^1.0@beta"
-  - "drupal/flysystem:^2.0@alpha"
   - "drupal/context:^4.0@beta"
-  - "islandora/controlled_access_terms:^2"
-  - "islandora/islandora_defaults:^2"
+  - "--with-all-dependencies islandora/islandora_defaults:^2 islandora/openseadragon:^2 islandora/controlled_access_terms:^2"
   - "islandora-rdm/islandora_fits:dev-8.x-1.x"
 drupal_composer_project_package: "drupal/recommended-project:^9.1"
-drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
+drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction --with-all-dependencies"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8
 drupal_db_name: drupal8
@@ -46,7 +42,6 @@ drupal_enable_modules:
   - rest
   - restui
   - devel
-  - features
   - search_api_solr
   - facets
   - content_browser

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -23,7 +23,7 @@ drupal_composer_dependencies:
   - "--with-all-dependencies islandora/islandora_defaults:^2 islandora/openseadragon:^2 islandora/controlled_access_terms:^2"
   - "islandora-rdm/islandora_fits:dev-8.x-1.x"
 drupal_composer_project_package: "drupal/recommended-project:^9.1"
-drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction --with-all-dependencies"
+drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8
 drupal_db_name: drupal8


### PR DESCRIPTION
**GitHub Issue**: (link)


# What does this Pull Request do?

Follow up to the discussion after the merge of #201  , which was failing if you had an existing site. The playbook would halt on composer require because the lock file had older versions of packages and the one-at-a-time update process was unable to complete.


# What's new?

This change removes explicit references to composer packages that are already listed as requirements by islandora or islandora_defaults.

It also puts the three packages islandora/islandora_defaults, islandoar/openseadragon and islandora/controlled_access_terms onto one line in the required package list, this is valid and makes composer update them all at once so that a hanging version specification in the lock file doesn't hold it up.


# How should this be tested?

Given a playbook that was built prior to the #201 changes , run 'vagrant provision' and observe the full run and that all Islandora packages are now at the 2.x branches.



# Additional Notes:

Successfully tested both the test above and a clean run.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
@whikloj  @seth-shaw-unlv   @rosiel 