### PR TITLE
Update README with macOS Monterey Vagrant workaround.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ This virtual machine **should not** be used in production **yet**.
 
 ## Variables
 
+### macOS 12.0 Monterey VirtualBox Workaround
+
+VirtualBox has not been updated to work fully with macOS Monterey as of October, 2021.
+A workaround exists, which is to run VirtualBox in non-headless mode.
+
+In your Vagrantfile, add the line 'v.gui = true' to the configuration section near the top:
+
+```
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.provider "virtualbox" do |v|
+    v.name = "Islandora 8 Ansible"
+    v.gui = true
+  end
+```
+
+Discussion of this issue can be found on this issue in Vagrant's GitHub project: https://github.com/hashicorp/vagrant/issues/12557
+
 ### Base box
 
 By default the Vagrantfile builds Islandora on a `ubuntu/focal64` base box.   


### PR DESCRIPTION
https://github.com/hashicorp/vagrant/issues/12557


# What does this Pull Request do?

vagrant up currently fails on macOS 12.0 Monterey. There is a workaround which is to not run it in headless mode.

This updates the README to advise of this until Oracle updates Virtualbox.

# What's new?

# How should this be tested?

Follow the steps in the README to run on macOS Monterey.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
