### PR TITLE
Install profile, 'standard' and 'demo' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This is an Ansible playbook for provisioning an instance of Islandora. This repository includes a Vagrantfile, so `vagrant up` will create a local virtual machine and run the playbook on it. For an alternative installation using Docker, please see [ISLE](https://islandora.github.io/documentation/installation/docker-compose/).
 
-This virtual machine **should not** be used in production **yet**.
+This virtual machine **should not** be used in production **yet**, however the Ansible inventory can be used as the basis for a server deployment with everything besides the Drupal port behind a firewall.
 
 ## Variables
 
@@ -14,6 +14,16 @@ This virtual machine **should not** be used in production **yet**.
 By default the Vagrantfile builds Islandora on a `ubuntu/focal64` base box.   
 
 The [Islandora 8 base box](https://app.vagrantup.com/islandora/boxes/8) is now deprecated.
+
+### Install Profile
+
+The Unix shell variable 'ISLANDORA_INSTALL_PROFILE' can be one of:
+
+standard - Installs a drupal/recommended-project base install and enables the Islandora and Islandora Defaults modules without any special configuration.
+
+demo - Installs the demo based on the install profile developed by Born Digital. This has a custom theme and more out-of-the-box customizations.
+
+This corresponds to the 'islandoar_profile' Ansible variable.
 
 ### System Resources
 
@@ -46,7 +56,7 @@ The default Drupal login details are:
 
 ### Fedora5
 
-The Fedora 5 REST API can be accessed at [http://localhost:8080/fcrepo/rest](http://localhost:8080/fcrepo/rest). 
+The Fedora 6 REST API can be accessed at [http://localhost:8080/fcrepo/rest](http://localhost:8080/fcrepo/rest). 
 
 Authentication is done via [Syn](https://github.com/Islandora-CLAW/Syn) using [JWT](https://jwt.io) tokens.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,13 +16,15 @@ $virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "I
 # Use 'islandora/8' if you just want to download a ready to run VM that is version 1.1.0 of Islandora
 # The 'islandora/8' box is no longer mantained.
 $vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "ubuntu/focal64")
+# Currently 'standard' and 'demo' are available.
+$drupalProfile = ENV.fetch("ISLANDORA_INSTALL_PROFILE", "standard")
 
 # vagrant is the main user
 $vagrantUser = "vagrant"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
-    v.name = "Islandora 8 Ansible"
+    v.name = "Islandora 8 Ansible Sandbox"
   end
 
   config.vm.hostname = $hostname
@@ -64,7 +66,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.host_vars = {
         "all" => { "ansible_ssh_user" => $vagrantUser }
       }
-      ansible.extra_vars = { "islandora_distro" => $vagrantBox }
+      ansible.extra_vars = { "islandora_distro" => $vagrantBox,
+                             "islandora_profile" => $drupalProfile }
     end
   end
 

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -83,3 +83,6 @@
       when:  defaultdir_exists.stat.exists == true
       become: yes
 
+    # Include install profile-specific variables
+    - name: include Drupal install profile specific variables
+      include_vars: "vars/{{ islandora_profile }}.yml"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -1,18 +1,9 @@
 ---
 
-drupal_build_composer_project: false
 drupal_composer_install_dir: /var/www/html/drupal
 drupal_core_owner: "{{ ansible_user }}"
 
-drupal_deploy: true
-drupal_build_composer: false
-drupal_deploy_repo: https://github.com/islandora-devops/islandora-sandbox
-drupal_deploy_version: install-profile
 drupal_deploy_dir: "{{ drupal_composer_install_dir }}"
-drupal_deploy_update: yes
-drupal_deploy_composer_install: yes
-drupal_deploy_accept_hostkey: yes
-
 
 drupal_core_path: "{{ drupal_deploy_dir }}/web"
 drupal_db_user: drupal8
@@ -21,7 +12,6 @@ drupal_db_backend: "{{ claw_db }}"
 drupal_db_host: "127.0.0.1"
 drupal_domain: "claw.dev"
 drupal_site_name: "Islandora 8"
-drupal_install_profile: islandora_install_profile_demo
 drupal_account_name: admin
 
 drupal_trusted_hosts:

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -1,62 +1,29 @@
 ---
 
-drupal_build_composer_project: true
+drupal_build_composer_project: false
 drupal_composer_install_dir: /var/www/html/drupal
 drupal_core_owner: "{{ ansible_user }}"
-drupal_composer_dependencies:
-  - "zaporylie/composer-drupal-optimizations:^1.1" 
-  - "drupal/devel:^4.0"
-  - "drupal/core-dev:^9.1"
-  - "drush/drush:^10.3"
-  - "drupal/rdfui:^1.0-beta1"
-  - "drupal/restui:^1.16"
-  - "drupal/search_api_solr:^4.1"
-  - "drupal/facets:^1.6"
-  - "drupal/content_browser:^1.0@alpha"
-  - "drupal/matomo:^1.7"
-  - "drupal/pdf:1.x-dev"
-  - "drupal/admin_toolbar:^2.0"
-  - "drupal/rest_oai_pmh:^1.0@beta"
-  - "drupal/transliterate_filenames:^1.3"
-  - "easyrdf/easyrdf:^1.1"
-  - "drupal/context:^4.0@beta"
-  - "--with-all-dependencies islandora/islandora_defaults:^2 islandora/openseadragon:^2 islandora/controlled_access_terms:^2"
-  - "islandora-rdm/islandora_fits:dev-8.x-1.x"
-drupal_composer_project_package: "drupal/recommended-project:^9.1"
-drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
-drupal_core_path: "{{ drupal_composer_install_dir }}/web"
+
+drupal_deploy: true
+drupal_build_composer: false
+drupal_deploy_repo: https://github.com/islandora-devops/islandora-sandbox
+drupal_deploy_version: install-profile
+drupal_deploy_dir: "{{ drupal_composer_install_dir }}"
+drupal_deploy_update: yes
+drupal_deploy_composer_install: yes
+drupal_deploy_accept_hostkey: yes
+
+
+drupal_core_path: "{{ drupal_deploy_dir }}/web"
 drupal_db_user: drupal8
 drupal_db_name: drupal8
 drupal_db_backend: "{{ claw_db }}"
 drupal_db_host: "127.0.0.1"
 drupal_domain: "claw.dev"
 drupal_site_name: "Islandora 8"
-drupal_install_profile: standard
+drupal_install_profile: islandora_install_profile_demo
 drupal_account_name: admin
-drupal_enable_modules:
-  - rdf
-  - responsive_image
-  - syslog
-  - serialization
-  - basic_auth
-  - rest
-  - restui
-  - devel
-  - search_api_solr
-  - facets
-  - content_browser
-  - matomo
-  - pdf
-  - admin_toolbar
-  - transliterate_filenames
-  - islandora_defaults
-  - controlled_access_terms_defaults
-  - islandora_defaults
-  - islandora_fits
-  - islandora_breadcrumbs
-  - islandora_iiif
-  - islandora_oaipmh
-  - islandora_search
+
 drupal_trusted_hosts:
   - ^localhost$
   - "{{ hostvars[groups['webserver'][0]].ansible_host }}"

--- a/post-install.yml
+++ b/post-install.yml
@@ -59,6 +59,9 @@
     - name: Set iiif manifest view
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml openseadragon.settings manifest_view iiif_manifest"
 
+    - name: Force Alpaca host setting to override install profile.
+      command: "{{ drush_path }} --root {{ drupal_core_path }} -y -l localhost:{{ apache_listen_port }} cset islandora.settings broker_url tcp://{{ hostvars[groups['karaf'][0]].ansible_host }}:61613"
+
     - name: Run migrations
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y -l localhost:{{ apache_listen_port }} --userid=1 mim --group=islandora"
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,7 +23,7 @@
   version: 2.0.2
 
 - src: geerlingguy.mysql
-  version: 3.1.0
+  version: 3.3.2
 
 - src: geerlingguy.postgresql
   version: 1.4.3
@@ -35,7 +35,7 @@
   version: 1.10.0
 
 - src: geerlingguy.drupal
-  version: 2.5.0
+  version: 4.3.0
 
 - src: geerlingguy.drush
   version: 3.1.1

--- a/roles/internal/Islandora-Devops.matomo/tasks/console_install.yml
+++ b/roles/internal/Islandora-Devops.matomo/tasks/console_install.yml
@@ -15,7 +15,7 @@
     target: "{{ webserver_document_root }}/matomo.sql"
     state: import
   ignore_errors: yes
-  when: motomo_sql_dump_create | changed
+  when: motomo_sql_dump_create is changed
 
 # create config.ini.php with default settings
 - name: Create config.ini.php

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -17,6 +17,8 @@
           ],
         ],
       ];
+      global $content_directories;
+      $content_directories['sync'] = $app_root.'/../content/sync';
     path: "{{ drupal_trusted_hosts_file }}"
     marker: // {mark} ANSIBLE MANAGED BLOCK
 
@@ -37,6 +39,13 @@
   file:
     state: directory
     path: "{{ webserver_app_drupal_config_path }}"
+    owner: "{{ webserver_app_user }}"
+    group: "{{ webserver_app_user }}"
+
+- name: Create content sync directory.
+  file:
+    state: directory
+    path: "{{ drupal_deploy_dir }}/content/sync"
     owner: "{{ webserver_app_user }}"
     group: "{{ webserver_app_user }}"
 

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -41,8 +41,12 @@
     group: "{{ webserver_app_user }}"
 
 - name: Import features
-  command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,islandora_defaults,islandora_search"
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,islandora_defaults"
 
+- name: Import search feature
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y 
+fim islandora_search"
+  when: islandora_profile == "standard"
 
 # masonry library is required by content_browser and not installed by composer due to issue 2971165.
 - name: Create drupal library directory.

--- a/roles/internal/webserver-app/tasks/jwt.yml
+++ b/roles/internal/webserver-app/tasks/jwt.yml
@@ -30,7 +30,10 @@
     - jwt.config.yml
     - key.key.islandora_rsa_key.yml
   register: drupal_jwt_config
-
+# Workaround for error validating configurations in islandora_defaults.
+- name: Enable Bartik
+  command: "{{ drush_path }} --root {{ drupal_core_path }} theme:enable bartik -y"
+  
 - name: Import JWT Config Into Drupal
   command: "{{ drush_path }} --root {{ drupal_core_path }} config-import -y --partial --source={{ webserver_app_jwt_config_path }}"
   when: drupal_jwt_config.changed is defined and drupal_jwt_config.changed

--- a/vars/demo.yml
+++ b/vars/demo.yml
@@ -1,0 +1,15 @@
+---
+
+drupal_build_composer_project: false
+
+drupal_deploy: true
+drupal_build_composer: false
+drupal_deploy_repo: https://github.com/islandora-devops/islandora-sandbox
+drupal_deploy_version: install-profile
+drupal_deploy_dir: "{{ drupal_composer_install_dir }}"
+drupal_deploy_update: yes
+drupal_deploy_composer_install: yes
+drupal_deploy_accept_hostkey: yes
+
+drupal_install_profile: islandora_install_profile_demo
+openseadragon_composer_item: "islandora/openseadragon:^2"

--- a/vars/standard.yml
+++ b/vars/standard.yml
@@ -1,0 +1,52 @@
+---
+
+drupal_build_composer_project: true
+
+
+drupal_composer_dependencies:
+  - "zaporylie/composer-drupal-optimizations:^1.1" 
+  - "drupal/devel:^4.0"
+  - "drupal/core-dev:^9.1"
+  - "drush/drush:^10.3"
+  - "drupal/rdfui:^1.0-beta1"
+  - "drupal/restui:^1.16"
+  - "drupal/search_api_solr:^4.1"
+  - "drupal/facets:^1.6"
+  - "drupal/content_browser:^1.0@alpha"
+  - "drupal/matomo:^1.7"
+  - "drupal/pdf:1.x-dev"
+  - "drupal/admin_toolbar:^2.0"
+  - "drupal/rest_oai_pmh:^1.0@beta"
+  - "drupal/transliterate_filenames:^1.3"
+  - "easyrdf/easyrdf:^1.1"
+  - "drupal/context:^4.0@beta"
+  - "--with-all-dependencies islandora/islandora_defaults:^2 islandora/openseadragon:^2 islandora/controlled_access_terms:^2"
+  - "islandora-rdm/islandora_fits:dev-8.x-1.x"
+drupal_composer_project_package: "drupal/recommended-project:^9.1"
+
+drupal_install_profile: standard
+drupal_enable_modules:
+  - rdf
+  - responsive_image
+  - syslog
+  - serialization
+  - basic_auth
+  - rest
+  - restui
+  - devel
+  - search_api_solr
+  - facets
+  - content_browser
+  - matomo
+  - pdf
+  - admin_toolbar
+  - transliterate_filenames
+  - islandora_defaults
+  - controlled_access_terms_defaults
+  - islandora_defaults
+  - islandora_fits
+  - islandora_breadcrumbs
+  - islandora_iiif
+  - islandora_oaipmh
+  - islandora_search
+openseadragon_composer_item: "islandora/openseadragon:^2"


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1194



* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

Uses install-profile branch, a D9 update, of https://github.com/Islandora-Devops/islandora-sandbox/tree/install-profile
Related PR on Islandora-Devops/islandora_install_profile_demo: https://github.com/Islandora-Devops/islandora_install_profile_demo/pull/3

# What does this Pull Request do?

Allows a user to run a playbook that installs either a standard Drupal distribution with Islandroa and Islandora Defaults enabled, without much more customization, or the 'demo' profile, based on the install profile provided to the community by Born DIgital and updated with Drupal 9 compatibility for this PR.

# What's new?

The base install should not change - it still uses the drupal/recommended-project composer project as a base, and it is the default option for the ISLANDORA_INSTALL_PROFILE variable.

The user now has an option to set that variable  to 'demo', which will check out the install-profile branch of the Islandora-Devops/islandora-sandbox project ** for now ** and run composer install when the Drupal role is executed.

THis can be a basis for Ansible to deploy an organization's own project, just by changing the drupal variables in var/demo to point to their own repo. It doesn't need to be in composer.

* Does this change require documentation to be updated? 

PR includes an update to the README. External install docs should be updated also.

* Does this change add any new dependencies? 

If 'demo' is install, it will point to the Islandora-Devops/islandora-sandbox composer project which depends on Islandora-Devops/islandora_install_profile_demo. 

* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 

I faccepted, we need to decide what the branch scheme of islandora-sandbox is 'main' is still needed elsewhere in its current form.


* Could this change impact execution of existing code?

Default is to stick with 'standard' so no.

# How should this be tested?

after running vagrant destroy:

Set a Unix shell variable:
export ISLANDORA_INSTALL_PROFILE=demo
Run 'vagrant up

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
