### PR TITLE
Mitigations for Log4J CVE-2021-44228

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -83,6 +83,14 @@
       when:  defaultdir_exists.stat.exists == true
       become: yes
 
+    - name: populate /etc/environment
+      lineinfile:
+        dest: "/etc/environment"
+        state: present
+        regexp: "^{{ item.key }}="
+        line: "{{ item.key }}={{ item.value}}"
+      with_items: "{{ os_environment }}"
+
     # Include install profile-specific variables
     - name: include Drupal install profile specific variables
       include_vars: "vars/{{ islandora_profile }}.yml"

--- a/inventory/vagrant/group_vars/all/main.yml
+++ b/inventory/vagrant/group_vars/all/main.yml
@@ -39,3 +39,8 @@ mysql_users:
 # Used by both the webserver and crayfish role for CentOS.
 php_enablerepo: "remi-php72"
 php_packages_state: "latest"
+
+# Log4j 
+os_environment:
+  - key: LOG4J_FORMAT_MSG_NO_LOOKUPS 
+    value: true

--- a/inventory/vagrant/group_vars/solr.yml
+++ b/inventory/vagrant/group_vars/solr.yml
@@ -1,4 +1,4 @@
-#solr_version: "7.7.3"
+solr_version: "8.11.1"
 
 solr_cores:
   - ISLANDORA

--- a/requirements.yml
+++ b/requirements.yml
@@ -29,7 +29,7 @@
   version: 1.4.3
 
 - src: geerlingguy.solr
-  version: 5.2.0
+  version: 5.3.0
 
 - src: geerlingguy.java
   version: 1.10.0

--- a/roles/internal/Islandora-Devops.tomcat8/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.tomcat8/tasks/main.yml
@@ -11,8 +11,7 @@
     - tomcat9
     - tomcat9-install
 
-- include: config.yml
-  static: no
+- include_tasks: config.yml
   tags:
     - tomcat9
     - tomcat9-config

--- a/solr.yml
+++ b/solr.yml
@@ -90,4 +90,5 @@
       command: "zip -q -d {{ item }} org/apache/logging/log4j/core/lookup/JndiLookup.class"
       with_items:
         - "{{ log4j_jars.stdout_lines }}"
+      ignore_errors: yes
       tags: solr

--- a/solr.yml
+++ b/solr.yml
@@ -79,7 +79,7 @@
         cache_valid_time: 3600
     
     - name: Find any instances of vulnurable Log4J core JAR file
-      command: "find / -name log4j-core-2.1[0,1,2,3,4,5,6].?.jar"
+      command: "find / -name log4j-core-2.1[0,1,2,3,4,5].?.jar"
       register: log4j_jars
       changed_when: false
       until: files_to_copy is not failed

--- a/solr.yml
+++ b/solr.yml
@@ -70,3 +70,24 @@
       retries: 20
       delay: 3
       tags: solr
+
+    # Log4j December 2021 vulnurability fix.
+    - name: Install zip command
+      apt:
+        name: "zip"
+        state: present
+        cache_valid_time: 3600
+    
+    - name: Find any instances of vulnurable Log4J core JAR file
+      command: "find / -name log4j-core-2.1[0,1,2,3,4,5,6].?.jar"
+      register: log4j_jars
+      changed_when: false
+      until: files_to_copy is not failed
+      retries: 5
+      tags: solr
+    
+    - name: Delete Log4J JNDI class from JARs
+      command: "zip -q -d {{ item }} org/apache/logging/log4j/core/lookup/JndiLookup.class"
+      with_items:
+        - "{{ log4j_jars.stdout_lines }}"
+      tags: solr


### PR DESCRIPTION
* Github Issue

https://github.com/Islandora/documentation/issues/2007

Taking a number of steps to close up the Shell4J vulnurability on fresh and existingsystems provisioned via Ansible.

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

https://logging.apache.org/log4j/2.x/security.html

# What does this Pull Request do?

As per the Apache notes in the Log4J CVE, setting an environment variable will turn off the remote lookup feature of Log4J's string formatter. This update sets this as a global environment on all servers.

Since there is some evidence this may not be sufficient, this PR also scans the filesystem and removes the JndiLookup class from any 2.x log4j-core JARs it finds.

# What's new?

Added a task to set values in the /etc/environment global variable file.

Adds a variable list in the inventory that currently contains just this one needed value.

Tasks in the Solr role to scan for vulnurable Log4J Core JARs.

* Does this change require documentation to be updated?  
  * No
* Does this change add any new dependencies? 
  * No
* Does this change require any other modifications to be made to the repository
  * No
* Could this change impact execution of existing code?
  * No

# How should this be tested?

Either a fresh or existing Islandora instance created from a playbook, run this playbook. 

Log in via SSH.

1. Check that the environment variable is set by running 'printing' and looking for LOG4J_FORMAT_MSG_NO_LOOKUPS is 'true'

2. Unzip a log4j JAR and verify that the JndiLookup.class file is gone:

Note that this was done after running provision on an existing site so the solr version is 8.6, not the current 8.11.1 which ships with a newer Log4J core JAR.

```bash
vagrant@islandora8:~/tmp$ unzip -q /opt/solr-8.6.0/server/lib/ext/log4j-core-2.13.2.jar
vagrant@islandora8:~/tmp$ cd org/apache/logging/log4j/core/lookup/
vagrant@islandora8:~/tmp/org/apache/logging/log4j/core/lookup$ ls *Jndi*
ls: cannot access '*Jndi*': No such file or directory

```

# Additional Notes:

All instances of log4j*.jar on the Vagrant box are either 1.x (not great but not vulnerable to this particular exploit) or are 2.13, unless provisioned fresh since the Solr version bump to 8.11.1.

```bash
root@islandora8:/# sudo find . -name "log4j*.jar"
./opt/solr-8.6.0/contrib/prometheus-exporter/lib/log4j-core-2.13.2.jar
./opt/solr-8.6.0/contrib/prometheus-exporter/lib/log4j-slf4j-impl-2.13.2.jar
./opt/solr-8.6.0/contrib/prometheus-exporter/lib/log4j-api-2.13.2.jar
./opt/solr-8.6.0/server/lib/ext/log4j-web-2.13.2.jar
./opt/solr-8.6.0/server/lib/ext/log4j-core-2.13.2.jar
./opt/solr-8.6.0/server/lib/ext/log4j-slf4j-impl-2.13.2.jar
./opt/solr-8.6.0/server/lib/ext/log4j-1.2-api-2.13.2.jar
./opt/solr-8.6.0/server/lib/ext/log4j-api-2.13.2.jar
./opt/fits-1.4.1/lib/droid/log4j-1.2.13.jar
./opt/fits-1.4.1/lib/log4j-1.2.17.jar
./opt/activemq/lib/optional/log4j-1.2.17.jar
./var/lib/tomcat9/webapps/bigdata/WEB-INF/lib/log4j-1.2.17.jar
./var/lib/tomcat9/webapps/fits/WEB-INF/lib/log4j-1.2.17.jar
./root/.gradle/wrapper/dists/gradle-5.0-all/4mxuau4c77thx8zlvtz4xiez7/gradle-5.0/samples/userguide/antMigration/fileDeps/groovy/libs/log4j-1.2.8.jar
./root/.gradle/wrapper/dists/gradle-5.0-all/4mxuau4c77thx8zlvtz4xiez7/gradle-5.0/samples/userguide/antMigration/fileDeps/kotlin/libs/log4j-1.2.8.jar

```

The change in the tomcat role is to fix a deprecation in Ansible's syntax that was preventing me from running the playbook on my homebrew's Ansible v. 2.12.


# Interested parties
, @Islandora-Devops/committers 
