### PR TITLE
Target ids directly as opposed to the group.

### DIFF
--- a/post-install.yml
+++ b/post-install.yml
@@ -63,7 +63,7 @@
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y -l localhost:{{ apache_listen_port }} cset islandora.settings broker_url tcp://{{ hostvars[groups['alpaca'][0]].ansible_host }}:61613"
 
     - name: Run migrations
-      command: "{{ drush_path }} --root {{ drupal_core_path }} -y -l localhost:{{ apache_listen_port }} --userid=1 mim --group=islandora"
+      command: "{{ drush_path }} --root {{ drupal_core_path }} -y -l localhost:{{ apache_listen_port }} --userid=1 mim islandora_tags,islandora_defaults_tags"
 
     - name: Add vagrant user to webserver app user group
       user: name={{ vagrant_user }}


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?

Migrate_tools was removed in https://github.com/Islandora/islandora/pull/859 to use Drush's built in runners. This targets the IDs directly as opposed to the non-existent `--group` parameter.
