### PR TITLE
Cantaloupe Support JP2 out of the box

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -69,18 +69,18 @@ cantaloupe_deploy_war_path: "{{ tomcat9_home }}/webapps"
 cantaloupe_user: tomcat
 cantaloupe_group: tomcat
 cantaloupe_admin_enabled: "true"
-cantaloupe_GrokProcessor_path_to_binaries: /user/local/bin
-cantaloupe_OpenJpegProcessor_path_to_binaries: /usr/local/bin
+cantaloupe_OpenJpegProcessor_path_to_binaries: /usr/bin
 cantaloupe_log_application_ConsoleAppender_enabled: "false"
 cantaloupe_log_application_FileAppender_enabled: "true"
 cantaloupe_log_application_FileAppender_pathname: "{{ cantaloupe_log_path }}/application.log"
 cantaloupe_log_access_FileAppender_enabled: "true"
 cantaloupe_log_access_FileAppender_pathname: "{{ cantaloupe_log_path }}/access.log"
 cantaloupe_FilesystemResolver_BasicLookupStrategy_path_prefix: /var/www/html/drupal/web/
-cantaloupe_processor_jp2: GrokProcessor
+cantaloupe_processor_jp2: OpenJpegProcessor
 cantaloupe_cache_source: FilesystemCache
 cantaloupe_cache_derivative: FilesystemCache
 cantaloupe_create_FilesystemCache_dir: yes
 cantaloupe_resolver_static: HttpSource
 cantaloupe_HttpResolver_BasicLookupStrategy_url_prefix: ""
 cantaloupe_processor_selection_strategy: ManualSelectionStrategy
+cantaloupe_StreamProcessor_retrieval_strategy: CacheStrategy

--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -69,6 +69,7 @@ cantaloupe_deploy_war_path: "{{ tomcat9_home }}/webapps"
 cantaloupe_user: tomcat
 cantaloupe_group: tomcat
 cantaloupe_admin_enabled: "true"
+cantaloupe_GrokProcessor_path_to_binaries: /user/local/bin
 cantaloupe_OpenJpegProcessor_path_to_binaries: /usr/local/bin
 cantaloupe_log_application_ConsoleAppender_enabled: "false"
 cantaloupe_log_application_FileAppender_enabled: "true"
@@ -76,9 +77,10 @@ cantaloupe_log_application_FileAppender_pathname: "{{ cantaloupe_log_path }}/app
 cantaloupe_log_access_FileAppender_enabled: "true"
 cantaloupe_log_access_FileAppender_pathname: "{{ cantaloupe_log_path }}/access.log"
 cantaloupe_FilesystemResolver_BasicLookupStrategy_path_prefix: /var/www/html/drupal/web/
-cantaloupe_processor_jp2: OpenJpegProcessor
+cantaloupe_processor_jp2: GrokProcessor
 cantaloupe_cache_source: FilesystemCache
 cantaloupe_cache_derivative: FilesystemCache
 cantaloupe_create_FilesystemCache_dir: yes
 cantaloupe_resolver_static: HttpSource
 cantaloupe_HttpResolver_BasicLookupStrategy_url_prefix: ""
+cantaloupe_processor_selection_strategy: ManualSelectionStrategy

--- a/post-install.yml
+++ b/post-install.yml
@@ -37,7 +37,7 @@
     - name: start tomcat9
       service:
         name: tomcat9
-        state: started    
+        state: restarted
 
     - name: Add admin to fedoraAdmin role
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y urol fedoraadmin admin"

--- a/roles/internal/Islandora-Devops.cantaloupe/README.md
+++ b/roles/internal/Islandora-Devops.cantaloupe/README.md
@@ -11,7 +11,7 @@ Available variables are listed below, along with default values:
 
 ```
 # Cantaloupe version
-cantaloupe_version: 4.1.7
+cantaloupe_version: 4.1.11
 # Where to extract the cantaloupe archive
 cantaloupe_install_root: /opt
 # Target of a symlink from the extracted cantaloupe archive 

--- a/roles/internal/Islandora-Devops.cantaloupe/defaults/main.yml
+++ b/roles/internal/Islandora-Devops.cantaloupe/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # Cantaloupe version
-cantaloupe_version: 4.1.7
+cantaloupe_version: 4.1.11
 # Where to extract the cantaloupe archive
 cantaloupe_install_root: /opt
 # Target of a symlink from the extracted cantaloupe archive

--- a/roles/internal/Islandora-Devops.cantaloupe/templates/cantaloupe.properties.j2
+++ b/roles/internal/Islandora-Devops.cantaloupe/templates/cantaloupe.properties.j2
@@ -409,6 +409,15 @@ GraphicsMagickProcessor.path_to_binaries = {{ cantaloupe_GraphicsMagickProcessor
 # ImageMagickProcessor
 #----------------------------------------
 
+# !! Optional absolute path of the directory containing the Grok
+# binary. Overrides the PATH.
+
+GrokProcessor.path_to_binaries = {{ cantaloupe_GrokProcessor_path_to_binaries }}
+
+#----------------------------------------
+# ImageMagickProcessor
+#----------------------------------------
+
 # !! Optional absolute path of the directory containing the ImageMagick
 # binary. Overrides the PATH.
 ImageMagickProcessor.path_to_binaries = {{ cantaloupe_ImageMagickProcessor_path_to_binaries }}

--- a/roles/internal/Islandora-Devops.cantaloupe/templates/cantaloupe.properties.j2
+++ b/roles/internal/Islandora-Devops.cantaloupe/templates/cantaloupe.properties.j2
@@ -409,11 +409,6 @@ GraphicsMagickProcessor.path_to_binaries = {{ cantaloupe_GraphicsMagickProcessor
 # ImageMagickProcessor
 #----------------------------------------
 
-# !! Optional absolute path of the directory containing the Grok
-# binary. Overrides the PATH.
-
-GrokProcessor.path_to_binaries = {{ cantaloupe_GrokProcessor_path_to_binaries }}
-
 #----------------------------------------
 # ImageMagickProcessor
 #----------------------------------------

--- a/roles/internal/Islandora-Devops.tomcat8/defaults/main.yml
+++ b/roles/internal/Islandora-Devops.tomcat8/defaults/main.yml
@@ -1,5 +1,6 @@
 tomcat9_packages:
   - tomcat9
+  - libopenjp2-tools
 tomcat9_admin_packages:
   - tomcat9-admin
 


### PR DESCRIPTION


# What does this Pull Request do?

The Cantaloupe image viewer was not properly set up to support JP2 out of the box. 

# What's new?

Added a few configurations and packages to load OpenJP2.
OPenJP2 tools Ubuntu package
Explicitly set manual selection strategy for Cantaloupe 
Use OpenJP2 rather than Grok. Keeping Grok as it is used to generate derivatives

* Does this change add any new dependencies? 

OpenJP2-tools Ubuntu packages

* Does this change require any other modifications to be made to the repository

no


* Could this change impact execution of existing code?

No

# How should this be tested?

From fresh playbook install:

1. Create a Repository Item object of type Page
2. Add Media of type File with a JP2, and tagged as Original File.
3. Copy the URL where the JP2 gets put, should be a /_flysystem URL 
4. URL-encode the image URL, e.g.,
```
$ php
<?php 
print(urlencode($url)):
```
5. GO to the Cantaloupe IIIF endpoints with this encoded URL:

http://localhost:8080/cantaloupe/iiif/2/{identifier}/info.json
http://localhost:8080/cantaloupe/iiif/2/{identifier}/full/full/0/default.jpg

You should see the JSON info and a tiled version of the image at those URLs.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
