### PR TITLE
Allow-list composer plugins

### DIFF
--- a/inventory/vagrant/group_vars/all/main.yml
+++ b/inventory/vagrant/group_vars/all/main.yml
@@ -14,6 +14,7 @@ islandora_extra_ubuntu_packages:
   - build-essential
   - vim
   - python3-mysqldb
+  - acl
 
 islandora_extra_centos_packages:
   - wget

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -1,6 +1,7 @@
 ---
 
 drupal_composer_install_dir: /var/www/html/drupal
+drupal_composer_project_options: "--prefer-dist --no-interaction"
 drupal_core_owner: "{{ ansible_user }}"
 
 drupal_deploy_dir: "{{ drupal_composer_install_dir }}"

--- a/roles/internal/composer-plugins-fix/tasks/main.yml
+++ b/roles/internal/composer-plugins-fix/tasks/main.yml
@@ -1,27 +1,12 @@
 ---
 
-  - name: Get webserver app user properties
-    user:
-      name: "{{ webserver_app_user }}"
-      state: present
-    register: webserver_app_user_properties
-
-  - name: Create composer config folder for webserver app user
-    file:
-      state: directory
-      path: "{{ webserver_app_user_properties.home }}/.config"
-      owner: "{{ webserver_app_user }}"
-      group: "{{ webserver_app_user }}"
-
   - name: Explicitly allow composer plugins for drupal
     community.general.composer:
       command: config
-      global_command: yes
+      global_command: true
       arguments: "allow-plugins.{{ item }} true"
     loop:
       - composer/installers
       - drupal/core-composer-scaffold
       - drupal/core-project-message
       - zaporylie/composer-drupal-optimizations
-    become_user: "{{ webserver_app_user }}"
-    become: yes

--- a/roles/internal/composer-plugins-fix/tasks/main.yml
+++ b/roles/internal/composer-plugins-fix/tasks/main.yml
@@ -1,20 +1,15 @@
 ---
 
-  - name: Webserver app user home folder debug
-    debug: var=ansible_env.HOME
-    become_user: "{{ webserver_app_user }}"
-    become: true
-
-  - name: Get webserver app user home folder
-    set_fact:
-      webserver_app_user_home: "{{ ansible_env.HOME }}"
-    become_user: "{{ webserver_app_user }}"
-    become: yes
+  - name: Get webserver app user properties
+    user:
+      name: "{{ webserver_app_user }}"
+      state: present
+    register: webserver_app_user_properties
 
   - name: Create composer config folder for webserver app user
     file:
       state: directory
-      path: "{{ webserver_app_user_home }}/.config"
+      path: "{{ webserver_app_user_properties.home }}/.config"
       owner: "{{ webserver_app_user }}"
       group: "{{ webserver_app_user }}"
 
@@ -23,10 +18,10 @@
       command: config
       global_command: yes
       arguments: "allow-plugins.{{ item }} true"
-    with_items:
-      composer/installers
-      drupal/core-composer-scaffold
-      drupal/core-project-message
-      zaporylie/composer-drupal-optimizations
+    loop:
+      - composer/installers
+      - drupal/core-composer-scaffold
+      - drupal/core-project-message
+      - zaporylie/composer-drupal-optimizations
     become_user: "{{ webserver_app_user }}"
     become: yes

--- a/roles/internal/composer-plugins-fix/tasks/main.yml
+++ b/roles/internal/composer-plugins-fix/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+
+  - name: Webserver app user home folder debug
+    debug: var=ansible_env.HOME
+    become_user: "{{ webserver_app_user }}"
+    become: true
+
+  - name: Get webserver app user home folder
+    set_fact:
+      webserver_app_user_home: "{{ ansible_env.HOME }}"
+    become_user: "{{ webserver_app_user }}"
+    become: yes
+
+  - name: Create composer config folder for webserver app user
+    file:
+      state: directory
+      path: "{{ webserver_app_user_home }}/.config"
+      owner: "{{ webserver_app_user }}"
+      group: "{{ webserver_app_user }}"
+
+  - name: Explicitly allow composer plugins for drupal
+    community.general.composer:
+      command: config
+      global_command: yes
+      arguments: "allow-plugins.{{ item }} true"
+    with_items:
+      composer/installers
+      drupal/core-composer-scaffold
+      drupal/core-project-message
+      zaporylie/composer-drupal-optimizations
+    become_user: "{{ webserver_app_user }}"
+    become: yes

--- a/vars/standard.yml
+++ b/vars/standard.yml
@@ -6,7 +6,6 @@ drupal_build_composer_project: true
 drupal_composer_dependencies:
   - "zaporylie/composer-drupal-optimizations:^1.1" 
   - "drupal/devel:^4.0"
-  - "drupal/core-dev:^9.1"
   - "drush/drush:^10.3"
   - "drupal/rdfui:^1.0-beta1"
   - "drupal/restui:^1.16"
@@ -20,9 +19,11 @@ drupal_composer_dependencies:
   - "drupal/transliterate_filenames:^1.3"
   - "easyrdf/easyrdf:^1.1"
   - "drupal/context:^4.0@beta"
-  - "--with-all-dependencies islandora/islandora_defaults:^2 islandora/openseadragon:^2 islandora/controlled_access_terms:^2"
+  - "drupal/flysystem:^2@beta"
+  - "islandora/islandora:^2.3"
+  - "islandora/islandora_defaults:^2.1"
   - "islandora-rdm/islandora_fits:dev-8.x-1.x"
-drupal_composer_project_package: "drupal/recommended-project:^9.1"
+drupal_composer_project_package: "drupal/recommended-project:^9@stable"
 
 drupal_install_profile: standard
 drupal_enable_modules:

--- a/vars/standard.yml
+++ b/vars/standard.yml
@@ -20,8 +20,8 @@ drupal_composer_dependencies:
   - "easyrdf/easyrdf:^1.1"
   - "drupal/context:^4.0@beta"
   - "drupal/flysystem:^2@beta"
-  - "islandora/islandora:^2.3"
-  - "islandora/islandora_defaults:^2.1"
+  - "islandora/islandora:*"
+  - "islandora/islandora_defaults:*"
   - "islandora-rdm/islandora_fits:dev-8.x-1.x"
 drupal_composer_project_package: "drupal/recommended-project:^9@stable"
 

--- a/webserver.yml
+++ b/webserver.yml
@@ -18,6 +18,7 @@
     - geerlingguy.php-mysql
     - geerlingguy.git
     - geerlingguy.composer
+    - composer-plugins-fix
     - geerlingguy.drush
     - geerlingguy.drupal
     - perms-fix


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

Discussion of composer's plans to disallow plugins by default starting in July 2022: 

https://www.drupal.org/project/drupal/issues/3255749

# What does this Pull Request do?

Explicitly allows composer plugins that Drupal uses.

# What's new?

grab latest releases.

Add the composer plugins Drupal uses to an explicit allow list to avoid possible breaking behaviour starting July 2022.

* Does this change require documentation to be updated? 

No

* Does this change add any new dependencies? 

No

* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 

No

* Could this change impact execution of existing code?
* 
Existing Drupal sites should not be affected. New installs will default to stable version of Drupal core.


# How should this be tested?


Run a fresh playbook install.

Test object creation to ensure derivatives are generated.

Run a composer command while logged in as vagrant. You should not get a warning about allowed plugins

# Additional Notes:


The 'acl' Ubuntu package was added to get around a problem with newer versions of Ansible when running as a less-privileged user. See:  https://github.com/ansible/ansible/issues/74830

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
