### PR TITLE
Composer stability fix to get Drupal 9.3.x.

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -1,6 +1,7 @@
 ---
 
 drupal_composer_install_dir: /var/www/html/drupal
+drupal_composer_project_options: "--prefer-dist --no-interaction"
 drupal_core_owner: "{{ ansible_user }}"
 
 drupal_deploy_dir: "{{ drupal_composer_install_dir }}"

--- a/vars/standard.yml
+++ b/vars/standard.yml
@@ -6,7 +6,6 @@ drupal_build_composer_project: true
 drupal_composer_dependencies:
   - "zaporylie/composer-drupal-optimizations:^1.1" 
   - "drupal/devel:^4.0"
-  - "drupal/core-dev:^9.1"
   - "drush/drush:^10.3"
   - "drupal/rdfui:^1.0-beta1"
   - "drupal/restui:^1.16"
@@ -20,9 +19,11 @@ drupal_composer_dependencies:
   - "drupal/transliterate_filenames:^1.3"
   - "easyrdf/easyrdf:^1.1"
   - "drupal/context:^4.0@beta"
-  - "--with-all-dependencies islandora/islandora_defaults:^2 islandora/openseadragon:^2 islandora/controlled_access_terms:^2"
+  - "drupal/flysystem:^2@beta"
+  - "islandora/islandora:^2.3"
+  - "islandora/islandora_defaults:^2.1"
   - "islandora-rdm/islandora_fits:dev-8.x-1.x"
-drupal_composer_project_package: "drupal/recommended-project:^9.1"
+drupal_composer_project_package: "drupal/recommended-project:^9@stable"
 
 drupal_install_profile: standard
 drupal_enable_modules:


### PR DESCRIPTION

# What does this Pull Request do?

Set composer default options to opt for stable versions by default.


# What's new?

The playbook was using geerlingguy.composer's default composer tags which included prefer-dist, this was causing composer create-project to get the development version of drupal/recommended-project.

We just needed to explicitly specify Flysystem  as a beta since it has no stable release.

* Does this change require documentation to be updated?  no 
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository no
 (i.e. Regeneration activity, etc.)? 
* Could this change impact execution of existing code? 
No, existing drupal installs aren't replaced by the playbook.


# How should this be tested?

Run a fresh playbook install.

Verify that the version of Drupal core is 9.3.x (as of June 8 2022).

Verify derivative creation.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
