### PR TITLE
Remove hard-coded Solr version when generating Drupal solr config.

### DIFF
--- a/inventory/vagrant/group_vars/solr.yml
+++ b/inventory/vagrant/group_vars/solr.yml
@@ -1,4 +1,4 @@
-solr_version: "8.11.1"
+solr_version: "8.11.2"
 
 solr_cores:
   - ISLANDORA

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -15,6 +15,6 @@
 
 - name: Create SOLR config.zip
   command:
-    cmd: "{{ drush_path }} --root {{ drupal_core_path }} -y solr-gsc default_solr_server solr_config.zip 7.1"
+    cmd: "{{ drush_path }} --root {{ drupal_core_path }} -y solr-gsc default_solr_server solr_config.zip {{ solr_version }}"
     chdir: "{{ drupal_core_path }}"
 


### PR DESCRIPTION
# What does this Pull Request do?

Make the Drupal solr config version match the installed version of Solr.

# What's new?

When generating the solr_config.zip file, the Drush command now uses the {{ solr_version }} from the inventory rather than the hard-coded "7.1".

* Does this change require documentation to be updated?  No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository 
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?


Run the playbook.

Go to  /admin/config/search/search-api/server/

Click on the Default Solr Server and default index links. Check that Drupal does not print a warning about  out-of-date solr config files 


# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
