### PR TITLE
Remove composer drupal optimizations

### DIFF
--- a/vars/standard.yml
+++ b/vars/standard.yml
@@ -4,7 +4,6 @@ drupal_build_composer_project: true
 
 
 drupal_composer_dependencies:
-  - "zaporylie/composer-drupal-optimizations:^1.1" 
   - "drupal/devel:^4.0"
   - "drush/drush:^10.3"
   - "drupal/rdfui:^1.0-beta1"


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-Devops/islandora-playbook/pull/217

We found that trying to allow composer plugins manually didn't work, so since Drupal has updated their recommended project, the only plugin causing problems is the composer optimizations, which was (AFAIK) created for Composer 1. 

# What does this Pull Request do?

remove `zaporylie/composer-drupal-optimizations:^1.1`

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  removes one.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? may slow down??

# How should this be tested?

Without this PR: vagrant up fails when installing composer dependencies because composer does not allow plugins
with this PR: Vagrant up (or provision) completes successfully.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag @alxp 