### PR TITLE
Fix composer invocation to _not_ run as root.

### DIFF
--- a/roles/internal/Islandora-Devops.crayfish/tasks/install.yml
+++ b/roles/internal/Islandora-Devops.crayfish/tasks/install.yml
@@ -65,7 +65,9 @@
   changed_when: true
   register: flex_package_info
   ignore_errors: true
-  
+  become: true
+  become_user: "{{ crayfish_user }}"
+
 - name: "Delete Houdini vendor folder to update symfony/flex"
   file:
     state: absent


### PR DESCRIPTION
Encountered during work on #226 (where this fix was going to be included as https://github.com/Islandora-Devops/islandora-playbook/pull/226/commits/d27c07c09162f8dc5cae5038b9b8ee97270b208b, but it was indicated that this could be of general utility in the meantime so cherry-picked it out to a separate branch)

Seems like [Composer 2.4.2](https://github.com/composer/composer/releases/tag/2.4.2) became more strict, preventing the command from returning completely.

---

Errors reported: 

```
TASK [Islandora-Devops.crayfish : Get symfony/flex version] ********************
Wednesday 14 September 2022  14:40:49 -0300 (0:00:02.263)       0:30:27.536 ***
fatal: [default]: FAILED! => {"changed": true, "msg": "Do not run Composer as root/super user! See https://getcomposer.org/root for details Aborting as no plugin should be loaded if running as super user is not explicitly allowed"}
...ignoring

TASK [Islandora-Devops.crayfish : Delete Houdini vendor folder to update symfony/flex] ***
Wednesday 14 September 2022  14:40:50 -0300 (0:00:01.391)       0:30:28.928 ***
fatal: [default]: FAILED! => {"msg": "The conditional check ''versions : * v1.13.3' in flex_package_info.stdout' failed. The error was: error while evaluating conditional ('versions : * v1.13.3' in flex_package_info.stdout): 'dict object' has no attribute 'stdout'\n\nThe error appears to be in '/home/adam/repos/islandora-playbook/roles/internal/Islandora-Devops.crayfish/tasks/install.yml': line 69, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Delete Houdini vendor folder to update symfony/flex\"\n  ^ here\n"}
```

... while before that (before the update to composer, presumably?), it would function, but still complain about running as root:

```
TASK [Islandora-Devops.crayfish : Get symfony/flex version] ********************
Friday 09 September 2022  16:22:32 -0300 (0:00:03.073)       0:42:46.311 ******
fatal: [default]: FAILED! => {"changed": true, "msg": "Do not run Composer as root/super user! See <https://getcomposer.org/root> for details No dependencies installed. Try running composer install or update. In ShowCommand.php line 297: Package \"symfony/flex\" not found in /var/www/html/Crayfish/Houdini/composer .json, try using --available (-a) to show all available packages. show [--all] [--locked] [-i|--installed] [-p|--platform] [-a|--available] [-s|--self] [-N|--name-only] [-P|--path] [-t|--tree] [-l|--latest] [-o|--outdated] [--ignore IGNORE] [-M|--major-only] [-m|--minor-only] [--patch-only] [-D|--direct] [--strict] [-f|--format FORMAT] [--no-dev] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<package> [<version>]]", "stdout": "Do not run Composer as root/super user! See <https://getcomposer.org/root> for details\nNo dependencies installed. Try running composer install or update.\n\nIn ShowCommand.php line 297:\n                                                                               \n  Package \"symfony/flex\" not found in /var/www/html/Crayfish/Houdini/composer  \n  .json, try using --available (-a) to show all available packages.            \n                                                                               \n\nshow [--all] [--locked] [-i|--installed] [-p|--platform] [-a|--available] [-s|--self] [-N|--name-only] [-P|--path] [-t|--tree] [-l|--latest] [-o|--outdated] [--ignore IGNORE] [-M|--major-only] [-m|--minor-only] [--patch-only] [-D|--direct] [--strict] [-f|--format FORMAT] [--no-dev] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<package> [<version>]]\n\n", "stdout_lines": ["Do not run Composer as root/super user! See <https://getcomposer.org/root> for details", "No dependencies installed. Try running composer install or update.", "", "In ShowCommand.php line 297:", "                                                                               ", "  Package \"symfony/flex\" not found in /var/www/html/Crayfish/Houdini/composer  ", "  .json, try using --available (-a) to show all available packages.            ", "                                                                               ", "", "show [--all] [--locked] [-i|--installed] [-p|--platform] [-a|--available] [-s|--self] [-N|--name-only] [-P|--path] [-t|--tree] [-l|--latest] [-o|--outdated] [--ignore IGNORE] [-M|--major-only] [-m|--minor-only] [--patch-only] [-D|--direct] [--strict] [-f|--format FORMAT] [--no-dev] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<package> [<version>]]", ""]}
...ignoring
```