### PR TITLE
Fix another instance of composer running as root.

### DIFF
--- a/roles/internal/Islandora-Devops.fits/tasks/build-fits-site.yml
+++ b/roles/internal/Islandora-Devops.fits/tasks/build-fits-site.yml
@@ -79,4 +79,4 @@
   ignore_errors: yes
   when: crayfits.stat.exists == False
   become: true
-
+  become_user: "{{ webserver_app_user }}"


### PR DESCRIPTION
Similar to #227, appears that the CrayFits installation was running as an unspecified user (so would be executed as the user running everything? `root`, apparently?)... so let's specify it.

---

Error encountered:

```
TASK [Islandora-Devops.fits : Run Composer On Fits Microservice] ***************
Thursday 15 September 2022  16:20:22 -0300 (0:00:00.544)       0:04:51.626 ****
fatal: [default]: FAILED! => {"changed": false, "msg": "Do not run Composer as root/super user! See https://getcomposer.org/root for details Aborting as no plugin should be loaded if running as super user is not explicitly allowed"}
...ignoring
```

... and checking on the system, the project doesn't appear to have been installed:

```
vagrant@islandora8:/var/www/html/CrayFits$ ls -l vendor
ls: cannot access 'vendor': No such file or directory
vagrant@islandora8:/var/www/html/CrayFits
```