### PR TITLE
no-pdfjs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ $virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "I
 $vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "ubuntu/focal64")
 
 # See the "install profile" section of the README for the full gamut available.
-$drupalProfile = ENV.fetch("ISLANDORA_INSTALL_PROFILE", "starter")
+$drupalProfile = ENV.fetch("ISLANDORA_INSTALL_PROFILE", "starter_dev")
 
 # vagrant is the main user
 $vagrantUser = "vagrant"
@@ -23,6 +23,7 @@ $vagrantUser = "vagrant"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.name = "Islandora 8 Ansible Sandbox"
+    v.gui = true
   end
 
   config.vm.hostname = $hostname

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ $virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "I
 $vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "ubuntu/focal64")
 
 # See the "install profile" section of the README for the full gamut available.
-$drupalProfile = ENV.fetch("ISLANDORA_INSTALL_PROFILE", "starter_dev")
+$drupalProfile = ENV.fetch("ISLANDORA_INSTALL_PROFILE", "starter")
 
 # vagrant is the main user
 $vagrantUser = "vagrant"
@@ -23,7 +23,6 @@ $vagrantUser = "vagrant"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.name = "Islandora 8 Ansible Sandbox"
-    v.gui = true
   end
 
   config.vm.hostname = $hostname

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -113,19 +113,6 @@
   changed_when: "'Do you want to update url_http' in set_matomo_server_url_config.stdout"
   when: webserver_app_configure_matomo
 
-# pdf.js library
-- name: ensure pdf.js directory exists
-  file:
-    path: "{{ drupal_external_libraries_directory }}/pdf.js"
-    state: directory
-
-- name: Unarchive pdf.js library
-  unarchive:
-    src: "https://github.com/mozilla/pdf.js/releases/download/v2.14.305/pdfjs-2.14.305-dist.zip"
-    dest: "{{ drupal_external_libraries_directory }}/pdf.js"
-    creates: "{{ drupal_external_libraries_directory }}/pdf.js/build"
-    remote_src: yes
-
 - name: Add project's /vendor/bin to $PATH (ubuntu)
   lineinfile:
     path: ~/.profile


### PR DESCRIPTION
**GitHub Issue**: [(link)](https://github.com/Islandora/islandora-starter-site/pull/26)

# What does this Pull Request do?

Now that both the [Install Profile](https://github.com/Islandora-Devops/islandora_install_profile_demo/blob/main/composer.json#L54-L65) and the [Starter Site](https://github.com/Islandora/islandora-starter-site/pull/26) include pdf.js in their composer.json, we don't have to install it in the playbook.

# What's new?

* Don't install pdfjs
* Does this change require documentation to be updated?  no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? no

# How should this be tested?

Spin up a site using `starter` or starter_dev, and test if pdfjs works.
Spin up a site using the install profile, and test if pdfjs works.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
