### PR TITLE
Mark failure ok when checking symfony/flex version.

### DIFF
--- a/roles/internal/Islandora-Devops.crayfish/tasks/install.yml
+++ b/roles/internal/Islandora-Devops.crayfish/tasks/install.yml
@@ -57,7 +57,7 @@
   become_user: "{{ crayfish_user }}"
   become: true
 
-- name: "Get symfony/flex version"
+- name: "Get symfony/flex version (failure OK)"
   composer:
     command: show
     working_dir: "{{ crayfish_install_dir }}/Houdini"


### PR DESCRIPTION
# What does this Pull Request do?

Big red error is scary. This lets you know it's ok.

# Interested parties
@alxp 
