### PR TITLE
Set crayfits url using variables for remote deployment.

### DIFF
--- a/inventory/vagrant/group_vars/alpaca.yml
+++ b/inventory/vagrant/group_vars/alpaca.yml
@@ -13,3 +13,4 @@
  alpaca_houdini_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host  }}:{{ apache_listen_port }}/houdini"
  alpaca_homarus_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host  }}:{{ apache_listen_port }}/homarus"
  alpaca_hypercube_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host  }}:{{ apache_listen_port }}/hypercube"
+ alpaca_fits_base_url: "http://{{ hostvars[groups['webserver'][0]].ansible_host  }}:{{ apache_listen_port }}/crayfits"


### PR DESCRIPTION
**why**: 

Alpaca gets configured to look for fits at `http://localhost:8000/crayfits`. This adds the URL to the inventory variables, so it gets set to the appropriate value.

Deploy to a non-localhost machine. 
Before this: no FITS derivatives and lots of errors in `/opt/alpaca/logs/alpaca.log`. 
After: hopefully you get FITS derivatives.