### PR TITLE
Add tempDirectory to Homarus config.

### DIFF
--- a/inventory/vagrant/group_vars/crayfish.yml
+++ b/inventory/vagrant/group_vars/crayfish.yml
@@ -1,5 +1,4 @@
 ---
-crayfish_version_tag: 3.x
 crayfish_db: "{{ islandora_db }}"
 
 crayfish_fedora_base_url: "http://{{ hostvars[groups['tomcat'][0]].ansible_host }}:8080/fcrepo/rest"

--- a/roles/internal/Islandora-Devops.crayfish/README.md
+++ b/roles/internal/Islandora-Devops.crayfish/README.md
@@ -7,16 +7,16 @@ An Ansible role that installs [Crayfish](https://github.com/Islandora/Crayfish) 
 
 ## Role Variables
 
-Available variables are listed below, along with default values:
+Key Available variables are listed below, along with default values:
 
 ```
 # Crayfish version to install
-crayfish_version_tag: 2.x
+crayfish_version_tag: 3.x
 # Crayfish services to install
 crayfish_services:
-  - Gemini
   - Houdini
   - Milliner
+  - Homarus
   - Hypercube
   - Recast
 # Default crayfish static JWT token
@@ -25,16 +25,27 @@ crayfish_syn_token: islandora
 crayfish_install_dir: /var/www/html/Crayfish
 # Crayfish log directory
 crayfish_log_dir: /var/log/islandora
-# Apache configuration directory
-crayfish_apache_conf_dir: /etc/apache2
+# URLs to Drupal and Fedora
+crayfish_drupal_base_url: http://localhost:8000
+crayfish_fedora_base_url: http://localhost:8080/fcrepo/rest
 ```
+More detailed variables can be seen in `defaults/main.yml`.
+
 Some OS dependent variables are set in vars/* but can be overridden if desired:
 
 ```
 # crayfish_user: www-data
 # httpd_conf_directory: /etc/apache2
 # crayfish_packages:
-#   - ImageMagick
+#   - imagemagick
+#   - tesseract-ocr
+#   - tesseract-ocr-fra
+#   - tesseract-ocr-deu
+#   - tesseract-ocr-ita
+#   - tesseract-ocr-spa
+#   - tesseract-ocr-srp
+#   - ffmpeg
+#   - poppler-utils
 ```
 =======
 `crayfish_db` can be set to: 

--- a/roles/internal/Islandora-Devops.crayfish/defaults/main.yml
+++ b/roles/internal/Islandora-Devops.crayfish/defaults/main.yml
@@ -103,6 +103,7 @@ crayfish_homarus_executable_config:
     default:
       mimetype: video/mp4
       format: mp4
+  tempdirectory: /tmp/
 
 # recast
 crayfish_recast_log_file: /var/log/islandora/recast.log

--- a/roles/internal/Islandora-Devops.crayfish/defaults/main.yml
+++ b/roles/internal/Islandora-Devops.crayfish/defaults/main.yml
@@ -1,4 +1,4 @@
-crayfish_version_tag: 2.x
+crayfish_version_tag: 3.x
 
 crayfish_services:
   - Houdini

--- a/roles/internal/Islandora-Devops.crayfish/templates/Homarus/services.yaml.j2
+++ b/roles/internal/Islandora-Devops.crayfish/templates/Homarus/services.yaml.j2
@@ -17,6 +17,7 @@ parameters:
     app.formats.defaults:
       mimetype: {{ crayfish_homarus_executable_config.formats.default.mimetype }}
       format: {{ crayfish_homarus_executable_config.formats.default.format }}
+    app.tempDirectory: {{ crayfish_homarus_executable_config.tempdirectory }}
 
 services:
     # default configuration for services in *this* file
@@ -42,4 +43,5 @@ services:
         $formats: '%app.formats.valid%'
         $defaults: '%app.formats.defaults%'
         $executable: '%app.executable%'
+        $tempDirectory: '%app.tempDirectory%'
       tags: ['controller.service_arguments']

--- a/roles/internal/Islandora-Devops.crayfish/tests/mysql.yml
+++ b/roles/internal/Islandora-Devops.crayfish/tests/mysql.yml
@@ -3,7 +3,7 @@
   become: yes
 
   vars:
-    crayfish_version_tag: "2.x"
+    crayfish_version_tag: "3.x"
     php_version: "7.4"
     php_packages_extra:
       - libapache2-mod-php7.4

--- a/roles/internal/Islandora-Devops.crayfish/tests/pgsql.yml
+++ b/roles/internal/Islandora-Devops.crayfish/tests/pgsql.yml
@@ -3,7 +3,7 @@
   become: yes
 
   vars:
-    crayfish_version_tag: "2.x"
+    crayfish_version_tag: "3.x"
     php_version: "7.4"
     php_packages_extra:
       - libapache2-mod-php7.4


### PR DESCRIPTION
**GitHub Issue**: none

A recent commit of Crayfish added a new parameter to the Homarus services.yaml config file.
When deploying with Vagrant, the default config file gets overwritten with one "managed by ansible" and is generated from a template.

Because of the missing variable, i was getting this error: ` Uncaught Exception: Cannot autowire service "App\\Islandora\\Homarus\\Controller\\HomarusController": argument "$tempDirectory" of method "__construct()" is type-hinted "string", you should configure its value explicitly.` and no homarus derivatives were being created.

This pull updates the template so it includes the new `$tempDirectory` variable and makes it configurable. Though it does not set a default value in the Vagrant inventory.

# What does this Pull Request do?

Makes homarus run! 

# What's new?

`tempDirectory` parameter in the Homarus settings.yaml file.

# How should this be tested?

Replicate:
* spin up playbook (use Crayfish on 3.x, which is currently default for Vagrant)
* Try to make an audio or video derivative that uses Homarus. No dice.

With this fix:
* Spin up playbook
* Try to make an audio or video derivative that uses Homarus. Success!

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@alxp @whikloj 