### PR TITLE
Let the install profile/starter site set the pseudo fields.

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -25,10 +25,4 @@ drupal_public_filesystem: "{{ drupal_core_path }}/sites/default/files"
 drupal_external_libraries_directory: "{{ drupal_core_path }}/libraries"
 fedora_base_url: "http://{{ hostvars[groups['tomcat'][0]].ansible_host }}:8080/fcrepo/rest/"
 drupal_jsonld_remove_format: true
-drupal_gemini_pseudo_bundles:
-  - islandora_object:node
-  - image:media
-  - file:media
-  - audio:media
-  - video:media
 openseadragon_composer_item: "islandora/openseadragon:^2"

--- a/post-install.yml
+++ b/post-install.yml
@@ -46,10 +46,6 @@
     - name: Set JSONLD Config
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml jsonld.settings remove_jsonld_format {{ drupal_jsonld_remove_format }}"
 
-    - name: Set pseudo field bundles
-      command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml islandora.settings gemini_pseudo_bundles.{{ item.0 }} {{ item.1 }}"
-      with_indexed_items: "{{ drupal_gemini_pseudo_bundles }}"
-
     - name: Set media urls
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml media.settings standalone_url true"
 


### PR DESCRIPTION
We don't need to set the bundles to have gemini pseudofields. that is done by the starter site, and also the install profile. 

**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

A brief description of what the intended result of the PR will be and/or what
 problem it solves.

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Changes x feature to such that y
* Added x
* Removed y
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
