### PR TITLE
Add proper copy-pasteable instructions to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ For an alternative installation using Docker, please see [ISLE](https://islandor
 
 ## Use
 
+With Vagrant (each of these steps may take several minutes!):
+
+```bash
+ISLANDORA_BUILD_BASE=true vagrant up         # Create the base box on a bare Ubuntu.
+vagrant package --output islandora_base      # Shut down the VM and save it as a file, islandora_base, which is created in this directory.
+vagrant destroy                              # You will be prompted to enter 'y' to destroy this VM
+vagrant up                                   # It will show it is importing the islandora_base base box, then will provision Islandora.
+```
+
 Detailed installation and usage instructions can be found on the [official installation documentation for Islandora](https://islandora.github.io/documentation/installation/playbook/).
 
 


### PR DESCRIPTION
**GitHub Issue**: 
None. But since a previous PR (below) there aren't instructions on how to use this repo on the README. You have to go to the Documentation. That's annoying, so I am replacing them.

* Text lifted from the original "split in two parts" pr: https://github.com/Islandora-Devops/islandora-playbook/pull/237
* This augments earlier related README changes: https://github.com/Islandora-Devops/islandora-playbook/pull/242

# What does this Pull Request do?

Basic (Vagrant) usage instructions right on the README.

# What's new?

A block of text with the four commands to run.

# How should this be tested?

* Run it. Does it work?

# Interested parties
@alxp 
