### PR TITLE
Rename incorrect queue name.

### DIFF
--- a/roles/internal/Islandora-Devops.alpaca/README.md
+++ b/roles/internal/Islandora-Devops.alpaca/README.md
@@ -115,7 +115,7 @@ alpaca_fcrepo_media: queue:islandora-indexing-fcrepo-media
 
 Indexing an external content resource:
 ```
-alpaca_fcrepo_external: queue:islandora-indexing-fcrepo-external
+alpaca_fcrepo_external: queue:islandora-indexing-fcrepo-file-external
 ```
 
 Configure default and maximum concurrent processes (-1 to leave as default):

--- a/roles/internal/Islandora-Devops.alpaca/defaults/main.yml
+++ b/roles/internal/Islandora-Devops.alpaca/defaults/main.yml
@@ -35,7 +35,7 @@ alpaca_fcrepo_milliner_baseUrl: "{{ alpaca_milliner_base_url }}"
 alpaca_fcrepo_node: queue:islandora-indexing-fcrepo-content
 alpaca_fcrepo_node_delete: queue:islandora-indexing-fcrepo-delete
 alpaca_fcrepo_media: queue:islandora-indexing-fcrepo-media
-alpaca_fcrepo_external: queue:islandora-indexing-fcrepo-external
+alpaca_fcrepo_external: queue:islandora-indexing-fcrepo-file-external
 alpaca_fcrepo_concurrent_consumers: -1
 alpaca_fcrepo_max_consumers: -1
 


### PR DESCRIPTION
**GitHub Issue**
* https://github.com/Islandora-Devops/islandora-playbook/issues/249

Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.):
also mentioned here: https://github.com/Islandora/documentation/pull/2191#issuecomment-1337839332 

# What does this Pull Request do?

Fixes a typo in the name of the external indexing queue.

# What's new?

* Changes name of queue to be correct.

# How should this be tested?

Make some media for files that DONT live in Fedora. Easiest way is to put something in that generates derivatives - right now all derivatives are configured to live in the public filesystem. 

Without this change: 
Manage ActiveMQ Broker (http://localhost:8161/ , username:admin password:admin). You see a lot of messages building up in the `islandora-indexing-fcrepo-file-external` queue  because nothing is reading it.

After:
You  should see messages being processed from the `islandora-indexing-fcrepo-file-external` queue!

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
