### PR TITLE
Increase PHP limits in vagrant inventory.

### DIFF
--- a/inventory/vagrant/group_vars/webserver/general.yml
+++ b/inventory/vagrant/group_vars/webserver/general.yml
@@ -3,3 +3,11 @@
 webserver_app: yes
 openseadragon_iiiv_set_var: yes
 openseadragon_iiiv_server: "http://{{ hostvars[groups['tomcat'][0]].ansible_host }}:8080/cantaloupe/iiif/2"
+
+# PHP settings for improved performance
+php_upload_max_filesize: 1G
+php_post_max_size: 1G
+php_max_input_time: 1000
+php_max_execution_time: 1000
+php_date_timezone: "America/Toronto"
+php_memory_limit: 1G


### PR DESCRIPTION
**GitHub Issue**: 
* #238 

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

increases PHP limits. I used @ruebot's values from the above-linked ticket (thank you!)

# What's new?

* Changes several PHP variables relating to filesize and memory limits. 

# How should this be tested?

* Technical: do these values get set and are the active PHP variable values?  (when i provisioned a VM with this, they were in php.ini (the apache2 copy but also cli and fpm) and is what shows on the phpinfo() accessed through Drupal's status report)
* Wisdom: do you have reason to think these numbers are not good numbers?

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@ruebot @alxp @whikloj 