### PR TITLE
Use "main" branch of islandora-sandbox for Install Profile ("demo").

### DIFF
--- a/vars/demo.yml
+++ b/vars/demo.yml
@@ -5,7 +5,7 @@ drupal_build_composer_project: false
 drupal_deploy: true
 drupal_build_composer: false
 drupal_deploy_repo: https://github.com/islandora-devops/islandora-sandbox
-drupal_deploy_version: install-profile
+drupal_deploy_version: main
 drupal_deploy_dir: "{{ drupal_composer_install_dir }}"
 drupal_deploy_update: yes
 drupal_deploy_composer_install: yes


### PR DESCRIPTION
A long time ago, the `install-profile` branch of the Islandora-Sandbox was the thing to install if you wanted to get the Install Profile. The PR was open for a long time and "use the install-profile branch" became the best practice. At that point it must have been merged into the playbook.

[ISLE-DC now uses the  main branch](https://github.com/Islandora-Devops/isle-dc/blob/development/Makefile#L355), so this updates the playbook to do the same.

@alxp @whikloj @g7morris 