### PR TITLE
Don't enable bartik.

### DIFF
--- a/roles/internal/webserver-app/tasks/jwt.yml
+++ b/roles/internal/webserver-app/tasks/jwt.yml
@@ -30,9 +30,6 @@
     - jwt.config.yml
     - key.key.islandora_rsa_key.yml
   register: drupal_jwt_config
-# Workaround for error validating configurations in islandora_defaults.
-- name: Enable Bartik
-  command: "{{ drush_path }} --root={{ drupal_core_path }} theme:enable bartik -y"
   
 - name: Import JWT Config Into Drupal
   command: "{{ drush_path }} --root={{ drupal_core_path }} config-import -y --partial --source={{ webserver_app_jwt_config_path }}"


### PR DESCRIPTION
**GitHub Issue**: addresses part of https://github.com/Islandora-Devops/islandora-playbook/issues/248

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
Doesn't enable bartik, since defaults is no longer being installed. When it gets installed, there are a number of Bartik blocks added to the starter site's config suite, which is bad.

# What's new?
* Don't enable bartik.
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? If you are requiring bartik to be enabled, make sure you do it somewhere.

# How should this be tested?

Before:
* load the starter site. Load a config or two in the UI.
* Export configs. Note that a lot of blocks were added to the configs.
After:
* load the starter site. Load some configs  in the UI.
* Export configs. No bartik blocks should be added to the configs.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
