### PR TITLE
Use latest version of starter site, when using starter.

### DIFF
--- a/vars/starter.yml
+++ b/vars/starter.yml
@@ -5,7 +5,7 @@ drupal_build_composer_project: true
 #drupal_composer_dependencies: []
 
 # Presently pointing at the main branch.
-drupal_composer_project_package: 'islandora/islandora-starter-site:dev-main'
+drupal_composer_project_package: 'islandora/islandora-starter-site:^0.2'
 
 # XXX: Strictly, irrelevant due to using the `--existing-config` flag.
 drupal_install_profile: minimal


### PR DESCRIPTION
**GitHub Issue**: #258 

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Uses a version constraint to pull the latest tag of the Starter Site, when using the `starter` option.

# How should this be tested?

First, you need to have created the base box with `ISLANDORA_BUILD_BASE=true vagrant up`. Then, with this PR, you should determine (using the differences between the latest commit and the latest tag) that you're on the latest tag. 

Sorry that we don't have a better way to detect the starter site version!

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
