### PR TITLE
Let site (starter or otherwise) set media urls.

### DIFF
--- a/post-install.yml
+++ b/post-install.yml
@@ -46,9 +46,6 @@
     - name: Set JSONLD Config
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml jsonld.settings remove_jsonld_format {{ drupal_jsonld_remove_format }}"
 
-    - name: Set media urls
-      command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml media.settings standalone_url true"
-
     - name: Set iiif url
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y cset --input-format=yaml islandora_iiif.settings iiif_server {{ openseadragon_iiiv_server }}"
 


### PR DESCRIPTION
**GitHub Issue**: in part, addresses #248 

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
Doesn't set media urls to have "Standalone URLs". This configuration is part of the starter site / install profile / whatever site you're using. The playbook currently insists on overriding whatever value you have set there in your site, which I think it shouldn't do.

# What's new?

* Removed a line that sets the value to be true.
* Does this change require documentation to be updated?  Some screenshots might need updating if they show media pages.
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? no

# How should this be tested?

Without this PR:
* install the starter site using "starter_dev"
* once installed, check the config diff using `drush cex --diff`. You should see that the media URLs have been set to True. 

With this PR:
* the `drush cex --diff` should not include this, because the value wasn't set in a way that contradicts the starter site.
 
# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
