### PR TITLE
Update starter

### DIFF
--- a/vars/starter.yml
+++ b/vars/starter.yml
@@ -5,7 +5,7 @@ drupal_build_composer_project: true
 #drupal_composer_dependencies: []
 
 # Presently pointing at the main branch.
-drupal_composer_project_package: 'islandora/islandora-starter-site:^0.2'
+drupal_composer_project_package: 'islandora/islandora-starter-site:^0.7'
 
 # XXX: Strictly, irrelevant due to using the `--existing-config` flag.
 drupal_install_profile: minimal

--- a/vars/starter.yml
+++ b/vars/starter.yml
@@ -5,7 +5,7 @@ drupal_build_composer_project: true
 #drupal_composer_dependencies: []
 
 # Presently pointing at the main branch.
-drupal_composer_project_package: 'islandora/islandora-starter-site:^0.7'
+drupal_composer_project_package: 'islandora/islandora-starter-site:~0.7'
 
 # XXX: Strictly, irrelevant due to using the `--existing-config` flag.
 drupal_install_profile: minimal


### PR DESCRIPTION
**GitHub Issue**:  see slack: https://islandora.slack.com/archives/C019U12D44Q/p1687185644319709

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Updates which minimum version of the starter site to use when using the `starter` option.

# What's new?

* Changes `0.2` (old!) to `0.7` (new)
* switches `^` for `~` to hopefully treat pre-release versions more leniently.

The  [composer docs](https://getcomposer.org/doc/articles/versions.md#tilde-version-range-) don't outright say, but imply that the tilde operator will get the latest 0.x release.

# How should this be tested?

Create a site with `starter`. You should get the 0.2 release. There will be no advanced search - that's the biggest different on the front page. (before advanced search, the search box is in the sidebar. With advanced search, it's a long search bar in the header).

After this pull: 
Create a site with `starter`. You should get the latest release.
Testing the "latest" ness - before spinning up, change the version constraint to `~0.6`. Then compare the version in the `.starter_site_version` file. It should still be 0.7. 

If the "latest" feature doesn't work, that's good to know but should not prevent this PR which is useful anyway. If that's the case then we'll push out a 1.0 release sooner.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
