### PR TITLE
Update to modern starter site and use caret operator.

### DIFF
--- a/vars/starter.yml
+++ b/vars/starter.yml
@@ -5,7 +5,7 @@ drupal_build_composer_project: true
 #drupal_composer_dependencies: []
 
 # Presently pointing at the main branch.
-drupal_composer_project_package: 'islandora/islandora-starter-site:~0.7'
+drupal_composer_project_package: 'islandora/islandora-starter-site:^1.2'
 
 # XXX: Strictly, irrelevant due to using the `--existing-config` flag.
 drupal_install_profile: minimal


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-Devops/islandora-playbook/issues/269#issuecomment-1861829422

# What does this Pull Request do?

Updates what version of Starter Site gets installed for the `starter` option.

# What's new?

`~0.7` becomes `^1.2`


# How should this be tested?

It should 
* install the starter site with no more issues than before
* land you on Drupal 10

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
