### PR TITLE
Don't separately install drush

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,7 +75,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.host_vars = {
         "all" => { "ansible_ssh_user" => $vagrantUser }
       }
-      ansible.extra_vars = { "islandora_distro" => $vagrantBox,
+      ansible.extra_vars = { "ansible_user" => $vagrantUser,
+                             "islandora_distro" => $vagrantBox,
                              "islandora_profile" => $drupalProfile,
                              "islandora_build_base_box" => $buildBaseBox }
     end

--- a/requirements.yml
+++ b/requirements.yml
@@ -37,6 +37,3 @@
 - src: geerlingguy.drupal
   version: 4.3.0
 
-- src: geerlingguy.drush
-  version: 3.1.1
-

--- a/webserver.yml
+++ b/webserver.yml
@@ -21,8 +21,6 @@
       when: islandora_build_base_box|bool == True
     - name: geerlingguy.composer
       when: islandora_build_base_box|bool == True
-    - name: geerlingguy.drush  # Include drush as drupal-openseadragon needs it.
-      when: islandora_build_base_box|bool == False
 
     - name: geerlingguy.drupal
       when: islandora_build_base_box|bool == False


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-Devops/islandora-playbook/issues/269


# What does this Pull Request do?

There are two things in this PR:
- add `vagrant_user` in the Vagrant file. Without this, the Vagrant installation doesn't work. I'm not sure how it worked before.
- fixes proposed by @RodBruce (many thanks!) for installing Drupal 10 (namely, _not_ installing the Drush Installer.)

Drush is still installed, but because it's required by the Starter Site or (hopefully) whatever you're using in place of the starter site. This is how it's supposed to be installed.

# What's new?

* Adds a value to `ansible_user` in the Vagrantfile
* Removes the `geerlingguy.drush` playbook role from `requirements.yml`
* Removes the call to that role in `webserver.yml`.

In regard to change number 3 in the linked issue, I found that i did not have to change anything in the drupal playbook for it to work. When Composer deployed the drupal project from the starter site, drush 12 was installed into the /vendor/bin folder. The [Drupal ansible role looks in this folder for Drush](https://github.com/geerlingguy/ansible-role-drupal/blob/master/tasks/main.yml#L43-L52). I ran the playbook using Vagrant with no other alterations (your change no.1 to the playbook version string has already been merged) and I got a Drupal 10.1.5 site with no Playbook errors. 

* Does this change require documentation to be updated?  No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

* clone this repo
* type `vagrant up` or use the [deploy instructions](https://islandora.github.io/documentation/installation/playbook/#deploying-to-a-remote-environment) to deploy it to another server.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
