### PR TITLE
Unset drupal_composer_dependencies so as to not separately require drush.

### DIFF
--- a/vars/starter.yml
+++ b/vars/starter.yml
@@ -2,7 +2,7 @@
 drupal_build_composer_project: true
 
 # None necessary, should all be described in the given project.
-#drupal_composer_dependencies: []
+drupal_composer_dependencies: []
 
 # Presently pointing at the main branch.
 drupal_composer_project_package: 'islandora/islandora-starter-site:^1.2'


### PR DESCRIPTION
**GitHub Issue**: #269 

Past issue that failed to account for this: #271 

# What does this Pull Request do?
Reverts a line that removes the default geerlingguy drupal role's tendency to install drush 10. We already install drush through having it in the Starter Site's composer.json so we don't need to do this.

A brief description of what the intended result of the PR will be and/or what
 problem it solves.

# What's new?

Un-breaks the playbook.

* Does this change require documentation to be updated?  no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? no

# How should this be tested?

* Run the playbook now. It should fail during the "islandora_build_base_box=false" step, when doing `Install dependencies with composer require` 
* With this PR, it should go through fine.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
