### PR TITLE
Add intl extension for php

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,3 +9,4 @@ php_packages_extra:
   - "php{{ php_version }}-gd"
   - "php{{ php_version }}-xml"
   - "php{{ php_version }}-curl"
+  - "php{{ php_version }}-intl"


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-Devops/islandora-playbook/issues/276

# What does this Pull Request do?

playbook fails with modern starter site since the changes to citation select that requires the citeproc library directly.

Adds the intl php extension so it works again.

# What's new?

See diff.

# How should this be tested?

* run playbook, it fails (see issue)
* with this fix, it works.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
