### PR TITLE
Deprecations, update mysql role, and set drush path.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ roles/external
 .project
 .github
 islandora_base
-!inventory/vagrant
 inventory/*
+!inventory/vagrant

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -26,3 +26,5 @@ drupal_external_libraries_directory: "{{ drupal_core_path }}/libraries"
 fedora_base_url: "http://{{ hostvars[groups['tomcat'][0]].ansible_host }}:8080/fcrepo/rest/"
 drupal_jsonld_remove_format: true
 openseadragon_composer_item: "islandora/openseadragon:^2"
+
+drush_path: "{{ drupal_deploy_dir }}/vendor/bin/drush"

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,7 +23,7 @@
   version: 2.0.2
 
 - src: geerlingguy.mysql
-  version: 3.3.2
+  version: 4.3.4
 
 - src: geerlingguy.postgresql
   version: 1.4.3

--- a/roles/internal/Islandora-Devops.activemq/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.activemq/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
-- include: user.yml
+- import_tasks: user.yml
   tags:
     - activemq
     - activemq-user
 
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - activemq
     - activemq-install

--- a/roles/internal/Islandora-Devops.alpaca/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.alpaca/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 
-- include: compile.yml
+- import_tasks: compile.yml
   tags:
     - alpaca
     - alpaca-compile
   when: alpaca_from_source
 
-- include: download.yml
+- import_tasks: download.yml
   tags:
     - alpaca
     - alpaca-download
   when: not alpaca_from_source
 
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - alpaca
     - alpaca-config

--- a/roles/internal/Islandora-Devops.blazegraph/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.blazegraph/tasks/main.yml
@@ -1,31 +1,31 @@
 ---
-- include: "define-home.yml"
+- import_tasks: "define-home.yml"
   tags:
     - blazegraph
     - blazegraph-config
     - blazegraph-install
 
-- include: "install-{{ ansible_os_family }}.yml"
+- include_tasks: "install-{{ ansible_os_family }}.yml"
   tags:
     - blazegraph
     - blazegraph-install
 
-- include: download.yml
+- import_tasks: download.yml
   tags:
     - blazegraph
     - blazegraph-download
 
-- include: logging.yml
+- import_tasks: logging.yml
   tags:
     - blazegraph
     - blazegraph-logging
 
-- include: "config-{{ ansible_os_family }}.yml"
+- include_tasks: "config-{{ ansible_os_family }}.yml"
   tags:
     - blazegraph
     - blazegraph-config
 
-- include: namespace.yml
+- import_tasks: namespace.yml
   tags:
     - blazegraph
     - blazegraph-namespace

--- a/roles/internal/Islandora-Devops.cantaloupe/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.cantaloupe/tasks/main.yml
@@ -1,28 +1,28 @@
 ---
 
-- include: os-vars.yml
+- import_tasks: os-vars.yml
   tags:
     - cantaloupe
     - cantaloupe-config
     - cantaloupe-install
 
-- include: "install-{{ ansible_os_family }}.yml"
+- include_tasks: "install-{{ ansible_os_family }}.yml"
   tags:
     - cantaloupe
     - cantaloupe-install
 
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - cantaloupe
     - cantaloupe-config
 
-- include: web.yml
+- import_tasks: web.yml
   tags:
     - cantaloupe
     - cantaloupe-web
   when: cantaloupe_deploy_war
 
-- include: cache.yml
+- import_tasks: cache.yml
   tags:
     - cantaloupe
     - cantaloupe-cache

--- a/roles/internal/Islandora-Devops.crayfish/tasks/install.yml
+++ b/roles/internal/Islandora-Devops.crayfish/tasks/install.yml
@@ -62,7 +62,7 @@
     state: directory
     owner: "{{ crayfish_user }}"
     group: "{{ crayfish_user }}"
-    mode: "urwx,gr,o-rwx"
+    mode: "u=rwx,g=r,o-rwx"
     recurse: yes
 
 - name: Install crayfish code

--- a/roles/internal/Islandora-Devops.crayfish/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.crayfish/tasks/main.yml
@@ -34,12 +34,12 @@
     - crayfish-install
     - crayfish-houdini
 
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - crayfish
     - crayfish-install
 
-- include: houdini.yml
+- import_tasks: houdini.yml
   tags:
     - crayfish
     - crayfish-houdini

--- a/roles/internal/Islandora-Devops.drupal-openseadragon/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.drupal-openseadragon/tasks/main.yml
@@ -13,12 +13,12 @@
   set_fact: openseadragon_drush_path="/usr/local/bin/drush"
   when: drush_path is not defined and drush_stat.stat.exists
 
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - openseadragon
     - openseadragon-install
 
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - openseadragon
     - openseadragon-config

--- a/roles/internal/Islandora-Devops.fcrepo-syn/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.fcrepo-syn/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
-- include: os-vars.yml
+- import_tasks: os-vars.yml
   tags:
     - fcrepo-syn
     - fcrepo-syn-config
     - fcrepo-syn-install
 
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - fcrepo-syn
     - fcrepo-syn-install
 
-- include: "config-{{ ansible_os_family }}.yml"
+- include_tasks: "config-{{ ansible_os_family }}.yml"
   tags:
     - fcrepo-syn
     - fcrepo-syn-config

--- a/roles/internal/Islandora-Devops.fcrepo/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.fcrepo/tasks/main.yml
@@ -1,16 +1,16 @@
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - fcrepo
     - fcrepo-install
 
-- include: db-mysql.yml
+- import_tasks: db-mysql.yml
   when: fcrepo_db_type == 'mysql' or fcrepo_persistence == 'jdbc-mysql'
   tags:
     - fedora
     - fedora-install
     - fedora-db
 
-- include: db-pgsql.yml
+- import_tasks: db-pgsql.yml
   when: fcrepo_db_type == 'postgresql' or fcrepo_persistence == 'jdbc-postgresql'
   become: yes
   tags:
@@ -18,7 +18,7 @@
     - fedora-install
     - fedora-db
 
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - fcrepo
     - fcrepo-config

--- a/roles/internal/Islandora-Devops.fits/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.fits/tasks/main.yml
@@ -4,26 +4,26 @@
 - name: include OS specific variables
   include_vars: "vars/{{ ansible_os_family }}.yml"
 
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - fits
     - fits-install
 
-- include: install-ws.yml
+- import_tasks: install-ws.yml
   tags:
     - fits
     - fits-ws
     - fits-ws-install
   when: fits_ws
 
-- include: config-ws.yml
+- import_tasks: config-ws.yml
   tags:
     - fits
     - fits-ws
     - fits-ws-config
   when: fits_ws
 
-- include: build-fits-site.yml
+- import_tasks: build-fits-site.yml
   tags:
     - fits
     - fits-install

--- a/roles/internal/Islandora-Devops.tomcat/tasks/main.yml
+++ b/roles/internal/Islandora-Devops.tomcat/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
-- include: "define-home.yml"
+- import_tasks: "define-home.yml"
   tags:
     - tomcat9
     - tomcat9-config
     - tomcat9-install
 
-- include: "install-{{ ansible_os_family }}.yml"
+- include_tasks: "install-{{ ansible_os_family }}.yml"
   when: "islandora_build_base_box is defined and islandora_build_base_box|bool == True"
   tags:
     - tomcat9

--- a/roles/internal/webserver-app/tasks/main.yml
+++ b/roles/internal/webserver-app/tasks/main.yml
@@ -9,25 +9,25 @@
   set_fact: drush_path="/usr/local/bin/drush"
   when: drush_path is not defined and drush_stat.stat.exists
 
-- include: apache.yml
+- import_tasks: apache.yml
   when: webserver_app_apache
   tags:
     - webserver-app
     - webserver-app-apache
 
-- include: drupal.yml
+- import_tasks: drupal.yml
   when: webserver_app_drupal
   tags:
     - webserver-app
     - webserver-app-drupal
 
-- include: jwt.yml
+- import_tasks: jwt.yml
   when: webserver_app_jwt
   tags:
     - webserver-app
     - webserver-app-jwt
 
-- include: solr.yml
+- import_tasks: solr.yml
   when: webserver_app_drupal
   tags:
     - webserver-app


### PR DESCRIPTION
**GitHub Issue**: 
* Fixes https://github.com/Islandora-Devops/islandora-playbook/issues/280


* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

* Replaces the 'include' directive that was removed in ansible 2.16 with 'import' or 'include_tasks'. see https://github.com/ansible/ansible/issues/76684 
* Updates the geerlingguy.mysql role because of replication error 
* Adds drush path as a variable to the vagrant inventory.
* Changes the format of the permissions string to that Ubuntu likes it.

# What's new?

* Does this change require documentation to be updated?  no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Try to spin up a playbook (local or remote). You will encounter:
* include is deprecated
* mysql replication fails
* drush is not found.

With this PR, it should run smoothly.

Can you test on Red Hat? (Can we support Red Hat? )

# Additional Notes:

Still trying to replicate this issue: https://github.com/Islandora-Devops/islandora-playbook/issues/279

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
